### PR TITLE
Fix NNSight syntax

### DIFF
--- a/tests/commons/model_wrapping/test_model_with_split_points.py
+++ b/tests/commons/model_wrapping/test_model_with_split_points.py
@@ -40,12 +40,12 @@ def encoder_lm() -> ModelWithSplitPoints:
 
 BERT_SPLIT_POINTS = [
     "cls.predictions.transform.LayerNorm",
-    "bert.encoder.layer.1",
+    "bert.encoder.layer.1.output",
     "bert.encoder.layer.3.attention.self.query",
 ]
 
 BERT_SPLIT_POINTS_SORTED = [
-    "bert.encoder.layer.1",
+    "bert.encoder.layer.1.output",
     "bert.encoder.layer.3.attention.self.query",
     "cls.predictions.transform.LayerNorm",
 ]
@@ -79,13 +79,15 @@ def test_activation_equivalence_batched_text_token_inputs(encoder_lm: ModelWithS
         assert torch.allclose(activations_txt[k], activations_ids[k])
 
 
-def test_index_by_layer_idx(encoder_lm: ModelWithSplitPoints):
-    """Test indexing by layer idx"""
-    split_points_with_layer_idx: list[str | int] = list(BERT_SPLIT_POINTS)
-    split_points_with_layer_idx[1] = 1  # instead of bert.encoder.layer.1
-    encoder_lm.split_points = split_points_with_layer_idx
-    assert encoder_lm.split_points == BERT_SPLIT_POINTS_SORTED, (
-        f"Failed for split_points: {BERT_SPLIT_POINTS}\n"
-        f"Expected: {BERT_SPLIT_POINTS_SORTED}\n"
-        f"Got:      {encoder_lm.split_points}"
-    )
+# TODO: This test was removed because we do not currently handle splitting over layers that return
+# outputs that are not tensors.
+# def test_index_by_layer_idx(encoder_lm: ModelWithSplitPoints):
+#    """Test indexing by layer idx"""
+#    split_points_with_layer_idx: list[str | int] = list(BERT_SPLIT_POINTS)
+#    split_points_with_layer_idx[1] = 1  # instead of bert.encoder.layer.1
+#    encoder_lm.split_points = split_points_with_layer_idx
+#    assert encoder_lm.split_points == BERT_SPLIT_POINTS_SORTED, (
+#        f"Failed for split_points: {BERT_SPLIT_POINTS}\n"
+#        f"Expected: {BERT_SPLIT_POINTS_SORTED}\n"
+#        f"Got:      {encoder_lm.split_points}"
+#    )

--- a/tests/concepts/methods/test_concept_bottleneck.py
+++ b/tests/concepts/methods/test_concept_bottleneck.py
@@ -76,7 +76,7 @@ def test_overcomplete_cbe(encoder_lm_splitter: ModelWithSplitPoints):
     """Test OvercompleteSAE and OvercompleteDictionaryLearning"""
 
     txt = ["Hello, my dog is cute", "The cat is on the [MASK]"]
-    split = "bert.encoder.layer.1"
+    split = "bert.encoder.layer.1.output"
     nb_concepts = 3
     encoder_lm_splitter.split_points = split
     activations = encoder_lm_splitter.get_activations(txt, select_strategy="flatten")


### PR DESCRIPTION
Fixes to `ModelWithSplitPoints.get_activations()` and added `get_latent_shape` back for `OvercompleteSAE` initialization, following suggested `nnsight` syntax.

Following these changes, split points are expected to return torch.Tensors. Hence, layers returning tuples (e.g. `bert.layers.1` in BERTForMaskedLM) will currently produce errors when used. An ad-hoc PR should be devoted to the handling of this case, since it is quite common and needs proper treatement (not just pulling out tensors from the tuple).