### PR TITLE
Issue60

### DIFF
--- a/interpreto/attributions/aggregations/base.py
+++ b/interpreto/attributions/aggregations/base.py
@@ -116,7 +116,7 @@ class MaskwiseMeanAggregator(Aggregator):
         results: Float[Tensor, "p t"],
         mask: Float[Tensor, "p l"],
     ) -> Float[Tensor, "t l"]:
-        return torch.einsum("pt,pl->tl", results, mask) / mask.sum(dim=1)
+        return torch.einsum("pt,pl->tl", results, mask) / mask.sum(dim=0)
 
 
 class OcclusionAggregator(Aggregator):


### PR DESCRIPTION
## Description

Change the aggregation dimension for the mask in `MaskwiseMeanAggregator` and `OcclusionAggregator`.

This bug was reported and discussed in the following issue.

## Related Issue

#60 

## Type of Change


- 🔧 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
