### PR TITLE
Introduce Insertion and Deletion metrics for attribution methods

### DIFF
--- a/docs/api/attributions/metrics/deletion.md
+++ b/docs/api/attributions/metrics/deletion.md
@@ -1,0 +1,3 @@
+# Deletion
+
+::: interpreto.attributions.metrics.insertion_deletion.Deletion

--- a/docs/api/attributions/metrics/insertion.md
+++ b/docs/api/attributions/metrics/insertion.md
@@ -1,0 +1,3 @@
+# Insertion
+
+::: interpreto.attributions.metrics.insertion_deletion.Insertion

--- a/interpreto/attributions/aggregations/insertion_deletion_aggregation.py
+++ b/interpreto/attributions/aggregations/insertion_deletion_aggregation.py
@@ -1,0 +1,94 @@
+# MIT License
+#
+# Copyright (c) 2025 IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL and FOR are research programs operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Aggregator for Insertion and Deletion metrics
+"""
+
+import torch
+from jaxtyping import Float
+from torch import Tensor
+
+from interpreto.attributions.aggregations.base import Aggregator
+
+
+class InsertionDeletionAggregator(Aggregator):
+    """
+    Aggregator for Insertion and Deletion metrics.
+
+    This class aggregates the results of the insertion and deletion metrics by filtering the results based on the
+    number of perturbations per target. The results are expected to be in the shape of (p * t, t), where p is the
+    number of perturbations per target and t is the number of targets. The aggregation is done by reshaping the results
+    to (p, t) where each row corresponds to a target and each column corresponds to a perturbation. For each target,
+    the results are aggregated by taking the values corresponding to the perturbations for that target.
+
+    Example:
+    Below is an example with t=3 targets (columns) and p=2 perturbations per target (rows). The interesting values are
+    represented by 1, 2, and 3, for each target. The "*" values are not considered in the aggregation. The aggregation
+    only keeps the scores of the perturbations corresponding to each target, resulting in a tensor of shape (p, t).
+    ```
+    results =
+    [
+        1a * *
+        1b * *
+        * 2a *
+        * 2b *
+        * * 3a
+        * * 3b
+    ]
+
+    aggregation =
+    [
+        1a 2a 3a
+        1b 2b 3b
+    ]
+    ```
+
+    """
+
+    def aggregate(
+        self,
+        results: Float[Tensor, "p*t t"],
+        mask: torch.Tensor | None = None,
+    ) -> Float[Tensor, "p t"]:
+        """
+        Aggregate the results of the insertion/deletion metric.
+
+        Args:
+            results (Float[Tensor, "p*t t"]): The results of the perturbation. Here, the results are expected to be
+                of shape (p * t, t).
+
+        Returns:
+            Float[Tensor, "t l"]: The aggregated results.
+        """
+        if results.shape[0] % results.shape[1] != 0:
+            raise ValueError(
+                f"The total number of perturbations ({results.shape[0]}) must be a multiple of "
+                f"the number of targets ({results.shape[1]})."
+            )
+
+        num_perturb_per_target = results.shape[0] // results.shape[1]
+        # Build a tensor of shape (num_perturb_per_target, num_targets) where for each target column, we only keep
+        # the perturbations corresponding to that target.
+        indices = torch.arange(results.shape[1]).repeat_interleave(num_perturb_per_target)  # shape (p * t,)
+        return results[torch.arange(results.shape[0]), indices].reshape(results.shape[1], num_perturb_per_target).T

--- a/interpreto/attributions/base.py
+++ b/interpreto/attributions/base.py
@@ -83,14 +83,27 @@ class AttributionOutput:
     Class to store the output of an attribution method.
     """
 
-    __slots__ = ("attributions", "elements", "model_task", "classes")
+    __slots__ = (
+        "attributions",
+        "elements",
+        "model_inputs_to_explain",
+        "targets",
+        "model_task",
+        "classes",
+        "granularity",
+        "inference_mode",
+    )
 
     def __init__(
         self,
         attributions: SingleAttribution,
         elements: list[str] | torch.Tensor,
+        model_inputs_to_explain: TensorMapping,
+        targets: torch.Tensor,
         model_task: ModelTask,
         classes: torch.Tensor | None = None,
+        granularity: Granularity = Granularity.DEFAULT,
+        inference_mode: Callable[[torch.Tensor], torch.Tensor] = InferenceModes.LOGITS,
     ):
         """
         Initializes an AttributionOutput instance.
@@ -119,16 +132,24 @@ class AttributionOutput:
         """
         self.attributions = attributions
         self.elements = elements
+        self.model_inputs_to_explain = model_inputs_to_explain
+        self.targets = targets
         self.model_task = model_task
         self.classes = classes
+        self.granularity = granularity
+        self.inference_mode = inference_mode
 
     def __repr__(self):
         return (
             f"AttributionOutput("
             f"attributions={repr(self.attributions)}, "
             f"elements={repr(self.elements)}, "
+            f"model_inputs_to_explain={repr(self.model_inputs_to_explain)}, "
+            f"targets={repr(self.targets)}, "
             f"model_task='{self.model_task}', "
-            f"classes={repr(self.classes)})"
+            f"classes={repr(self.classes)}), "
+            f"granularity={self.granularity}, "
+            f"inference_mode={self.inference_mode.__name__}"
         )
 
     def __str__(self):
@@ -136,8 +157,12 @@ class AttributionOutput:
             f"AttributionOutput("
             f"attributions={self.attributions}, "
             f"elements={self.elements}, "
+            f"model_inputs_to_explain={self.model_inputs_to_explain}, "
+            f"targets={self.targets}, "
             f"model_task='{self.model_task}', "
-            f"classes={self.classes})"
+            f"classes={self.classes}), "
+            f"granularity={self.granularity}, "
+            f"inference_mode={self.inference_mode.__name__}"
         )
 
 
@@ -337,9 +362,9 @@ class AttributionExplainer:
     def explain(
         self,
         model_inputs: ModelInputs,
-        targets: torch.Tensor
-        | Iterable[torch.Tensor]
-        | None = None,  # TODO: create specific target type for classification and generation
+        targets: (
+            torch.Tensor | Iterable[torch.Tensor] | None
+        ) = None,  # TODO: create specific target type for classification and generation
         **model_kwargs: Any,
     ) -> Iterable[AttributionOutput]:
         """
@@ -371,7 +396,7 @@ class AttributionExplainer:
         # Process the inputs and targets for explanation
         # If targets are not provided, create them from model_inputs_to_explain.
         model_inputs_to_explain: Iterable[TensorMapping]
-        sanitized_targets: Iterable[Float[torch.Tensor, "n t"]]
+        sanitized_targets: Iterable[Float[torch.Tensor, "t"]]
         model_inputs_to_explain, sanitized_targets_gen = self.process_inputs_to_explain_and_targets(
             sanitized_model_inputs, targets, **model_kwargs
         )
@@ -428,8 +453,8 @@ class AttributionExplainer:
 
         # Create and return AttributionOutput objects with the contributions and decoded token sequences:
         results = []
-        for contribution, elements, target in zip(
-            granular_contributions, granular_inputs_texts, sanitized_targets, strict=True
+        for contribution, model_input, elements, target in zip(
+            granular_contributions, model_inputs_to_explain, granular_inputs_texts, sanitized_targets, strict=True
         ):
             if self.inference_wrapper.__class__.__name__ == "GenerationInferenceWrapper":
                 model_task = ModelTask.GENERATION
@@ -445,7 +470,14 @@ class AttributionExplainer:
                     f"Model type {self.inference_wrapper.model.__class__.__name__} not supported for AttributionExplainer."
                 )
             attribution_output = AttributionOutput(
-                attributions=contribution, elements=elements, model_task=model_task, classes=classes
+                attributions=contribution,
+                elements=elements,
+                model_inputs_to_explain=model_input,
+                model_task=model_task,
+                classes=classes,
+                targets=target,
+                granularity=self.granularity,
+                inference_mode=self.inference_wrapper.mode,
             )
             results.append(attribution_output)
         return results

--- a/interpreto/attributions/methods/kernel_shap.py
+++ b/interpreto/attributions/methods/kernel_shap.py
@@ -98,7 +98,7 @@ class KernelShap(MultitaskExplainerMixin, AttributionExplainer):
         model, replace_token_id = self._set_tokenizer(model, tokenizer)
 
         perturbator = ShapTokenPerturbator(
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             inputs_embedder=model.get_input_embeddings(),
             granularity=granularity,
             replace_token_id=replace_token_id,
@@ -113,7 +113,7 @@ class KernelShap(MultitaskExplainerMixin, AttributionExplainer):
 
         super().__init__(
             model=model,
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             perturbator=perturbator,
             aggregator=aggregator,
             batch_size=batch_size,

--- a/interpreto/attributions/methods/lime.py
+++ b/interpreto/attributions/methods/lime.py
@@ -106,7 +106,7 @@ class Lime(MultitaskExplainerMixin, AttributionExplainer):
         model, replace_token_id = self._set_tokenizer(model, tokenizer)
 
         perturbator = RandomMaskedTokenPerturbator(
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             inputs_embedder=model.get_input_embeddings(),
             n_perturbations=n_perturbations,
             replace_token_id=replace_token_id,
@@ -122,7 +122,7 @@ class Lime(MultitaskExplainerMixin, AttributionExplainer):
 
         super().__init__(
             model=model,
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             perturbator=perturbator,
             aggregator=aggregator,
             batch_size=batch_size,

--- a/interpreto/attributions/methods/occlusion.py
+++ b/interpreto/attributions/methods/occlusion.py
@@ -93,7 +93,7 @@ class Occlusion(MultitaskExplainerMixin, AttributionExplainer):
         model, replace_token_id = self._set_tokenizer(model, tokenizer)
 
         perturbator = OcclusionPerturbator(
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             inputs_embedder=model.get_input_embeddings(),
             granularity=granularity,
             replace_token_id=replace_token_id,
@@ -101,7 +101,7 @@ class Occlusion(MultitaskExplainerMixin, AttributionExplainer):
 
         super().__init__(
             model=model,
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             batch_size=batch_size,
             device=device,
             perturbator=perturbator,

--- a/interpreto/attributions/methods/occlusion.py
+++ b/interpreto/attributions/methods/occlusion.py
@@ -73,7 +73,6 @@ class Occlusion(MultitaskExplainerMixin, AttributionExplainer):
         granularity: Granularity = Granularity.WORD,
         inference_mode: Callable[[torch.Tensor], torch.Tensor] = InferenceModes.LOGITS,
         device: torch.device | None = None,
-        replace_token_id: int | None = None,
     ):
         """
         Initialize the attribution method.

--- a/interpreto/attributions/methods/sobol_attribution.py
+++ b/interpreto/attributions/methods/sobol_attribution.py
@@ -104,7 +104,7 @@ class Sobol(MultitaskExplainerMixin, AttributionExplainer):
         model, replace_token_id = self._set_tokenizer(model, tokenizer)
 
         perturbator = SobolTokenPerturbator(
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             inputs_embedder=model.get_input_embeddings(),
             granularity=granularity,
             replace_token_id=replace_token_id,
@@ -119,7 +119,7 @@ class Sobol(MultitaskExplainerMixin, AttributionExplainer):
 
         super().__init__(
             model=model,
-            tokenizer=tokenizer,
+            tokenizer=self.tokenizer,
             perturbator=perturbator,
             aggregator=aggregator,
             batch_size=batch_size,

--- a/interpreto/attributions/metrics/__init__.py
+++ b/interpreto/attributions/metrics/__init__.py
@@ -1,0 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2025 IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL and FOR are research programs operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from interpreto.attributions.metrics.insertion_deletion import Deletion, Insertion

--- a/interpreto/attributions/metrics/insertion_deletion.py
+++ b/interpreto/attributions/metrics/insertion_deletion.py
@@ -1,0 +1,272 @@
+# MIT License
+#
+# Copyright (c) 2025 IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL and FOR are research programs operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Deletion and Insertion metrics
+
+This module contains classes for the Insertion and Deletion metrics, which are perturbation-based metrics where we
+iteratively include/occlude more tokens from the input text based on the importance of the attributions.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import numpy as np
+import torch
+from transformers.tokenization_utils import PreTrainedTokenizer
+
+from interpreto.attributions.aggregations.insertion_deletion_aggregation import InsertionDeletionAggregator
+from interpreto.attributions.base import AttributionExplainer, AttributionOutput, MultitaskExplainerMixin
+from interpreto.attributions.perturbations import DeletionPerturbator, InsertionPerturbator
+from interpreto.commons.generator_tools import split_iterator
+from interpreto.commons.granularity import Granularity
+from interpreto.model_wrapping.inference_wrapper import InferenceModes
+from interpreto.typing import TensorMapping
+
+
+class InsertionDeletionBase(MultitaskExplainerMixin, AttributionExplainer):
+    """
+    Abstract base class for Insertion and Deletion metrics. Only the perturbator class is different between the two
+    metrics.
+
+    This class implements the core logic for insertion and deletion metrics, where tokens are either inserted or
+    deleted from the input text based on their importance scores. The perturbator class is responsible for
+    handling the specific perturbation logic (insertion or deletion).
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        tokenizer: PreTrainedTokenizer,
+        batch_size: int = 4,
+        granularity: Granularity = Granularity.TOKEN,
+        device: torch.device | None = None,
+        n_perturbations: int = 100,
+        max_percentage_perturbed: float = 1.0,
+    ):
+        """
+        Initializes the metric.
+
+        Args:
+            model (PreTrainedModel): model used to generate explanations
+            tokenizer (PreTrainedTokenizer): Hugging Face tokenizer associated with the model
+            batch_size (int): batch size for the inference of the metric
+            granularity (Granularity): granularity level of the perturbations (token, word, sentence, etc.)
+            device (torch.device): device on which the attribution method will be run
+            n_perturbations (int): number of perturbations from which the metric will be computed (i.e. the number of
+                steps from which the AUC will be computed).
+            max_percentage_perturbed (float): maximum percentage of elements in the sequence to be perturbed. Defaults
+                to 1.0, meaning that all elements can be perturbed. If set to 0.5, only half of the elements will be
+                perturbed (i.e. only the 50% most important). This is useful to avoid perturbing too many elements with
+                low scores in long sequences.
+        """
+        model, replace_token_id = self._set_tokenizer(model, tokenizer)
+
+        super().__init__(
+            model=model,
+            tokenizer=self.tokenizer,
+            batch_size=batch_size,
+            device=device,
+            perturbator=self._perturbator_class(
+                tokenizer=self.tokenizer,
+                granularity=granularity,
+                n_perturbations=n_perturbations,
+                max_percentage_perturbed=max_percentage_perturbed,
+                replace_token_id=replace_token_id,
+            ),
+            aggregator=InsertionDeletionAggregator(),
+            granularity=granularity,
+            inference_mode=InferenceModes.SOFTMAX,
+            use_gradient=False,
+        )
+
+    @property
+    @abstractmethod
+    def _perturbator_class(self) -> Callable:
+        """
+        Returns the perturbator class used for insertion or deletion.
+
+        This method should be overridden in subclasses to return the appropriate perturbator.
+        """
+        raise NotImplementedError()
+
+    def explain(*args, **kwargs):
+        """This method, inherited from AttributionExplainer, is not implemented for Insertion and Deletion metrics."""
+
+        raise NotImplementedError(
+            "Insertion and Deletion metrics do not support `explain` method. "
+            "Use the `evaluate` method to evaluate the deletion metric."
+        )
+
+    def evaluate(self, attributions_outputs: Iterable[AttributionOutput]):
+        """
+        Evaluates the insertion or deletion metric based on the provided attributions.
+
+        Args:
+            attributions_outputs (Iterable[AttributionOutput]): Outputs from the attribution method.
+
+        Returns:
+            tuple: A tuple containing:
+                - the average AUC score across all attributions
+                - a list of scores for each sequence, where each element is a numpy array of scores.
+        """
+
+        # Assert that the granularity of all attributions is the same as the granularity of the deletion.
+        grans = [a.granularity for a in attributions_outputs]
+        if not all(g == self.granularity for g in grans):
+            raise ValueError(
+                f"All attributions must have the same granularity as the insertion/deletion metric. "
+                f"Expected {self.granularity} for all attributions."
+                "If you need to use attributions with different granularities, please raise an issue on GitHub."
+            )
+
+        # Create perturbation masks and perturb inputs based on the masks.
+        pert_generator: Iterable[TensorMapping]
+        mask_generator: Iterable[torch.Tensor | None]
+        pert_generator, mask_generator = split_iterator(
+            self.perturbator.perturb(a.model_inputs_to_explain, attributions=a.attributions)
+            for a in attributions_outputs
+        )
+
+        # Compute the score on perturbed inputs:
+        scores: Iterable[torch.Tensor] = self.get_scores(
+            pert_generator, (a.targets.to(self.device) for a in attributions_outputs)
+        )
+
+        # Aggregate the scores using the aggregator function and the perturbation masks.
+        cleaned_scores = (
+            self.aggregator(score.detach(), mask.to(self.device) if mask is not None else None).squeeze(0)
+            for score, mask in zip(scores, mask_generator, strict=True)
+        )
+
+        # Compute AUC using trapezoidal rule
+        cleaned_scores = [s.cpu().numpy() for s in cleaned_scores]
+        aucs = []
+        for s in cleaned_scores:
+            auc = ((s.sum(axis=0) - 0.5 * (s[0] + s[-1])) / (len(s) - 1)).mean()  # Average AUC across targets
+            aucs.append(auc)
+        auc = float(np.mean(aucs))
+
+        return auc, cleaned_scores
+
+
+class Insertion(InsertionDeletionBase):
+    """
+    The insertion metric measures the quality of an attribution method by evaluating how the prediction score of a
+    model improves when the most important elements of a sequence are gradually added. The importance of the elements
+    is determined by the attribution-based method.
+
+    A curve is built by computing the prediction score while iteratively inserting the most important elements,
+    starting from a masked sequence. The area under this curve (AUC) is then computed to quantify the quality of the
+    attribution method. The `evaluate` method returns both:
+    - the average AUC across all sequences and targets,
+    - for each sequence-target pair, the scores associated to the successive insertions.
+
+    An attribution method is considered good if the AUC is high, meaning that the model's prediction score increases
+    significantly as the most important elements are added back to the sequence. Conversely, a low AUC indicates that
+    the attribution method is not effective in identifying the most important elements for the model's prediction.
+
+    This metric only evaluates the order of importance of the elements in the sequence, not their actual values.
+
+    Examples:
+        >>> from interpreto.attributions.metrics import Insertion
+        >>>
+        >>> # Get explanations from an attribution method
+        >>> explainer = Method(model, tokenizer, kwargs)
+        >>> explanations = explainer(inputs, targets)
+        >>>
+        >>> # Run the insertion metric
+        >>> metric = Insertion(model, tokenizer, n_perturbations=100)
+        >>> auc, metric_scores = metric.evaluate(explanations)
+
+    Args:
+        model (PreTrainedModel): model used to generate explanations
+        tokenizer (PreTrainedTokenizer): Hugging Face tokenizer associated with the model
+        batch_size (int): batch size for the inference of the metric
+        granularity (Granularity): granularity level of the perturbations (token, word, sentence, etc.)
+        device (torch.device): device on which the attribution method will be run
+        n_perturbations (int): number of perturbations from which the metric will be computed (i.e. the number of
+            steps from which the AUC will be computed).
+        max_percentage_perturbed (float): maximum percentage of elements in the sequence to be perturbed. Defaults
+            to 1.0, meaning that all elements can be perturbed. If set to 0.5, only half of the elements will be
+            perturbed (i.e. only the 50% most important). This is useful to avoid perturbing too many elements with
+            low scores in long sequences.
+    """
+
+    @property
+    def _perturbator_class(self) -> Callable:
+        """Return the perturbator class used for insertion."""
+        return InsertionPerturbator
+
+
+class Deletion(InsertionDeletionBase):
+    """
+    The deletion metric measures the quality of an attribution method by evaluating how the prediction score of a
+    model drops when the most important elements of a sequence are gradually removed. The importance of the elements
+    is determined by the attribution-based method.
+
+    A curve is built by computing the prediction score while iteratively masking the most important elements,
+    starting from the whole sequence. The area under this curve (AUC) is then computed to quantify the quality of the
+    attribution method. The `evaluate` method returns both:
+    - the average AUC across all sequences and targets,
+    - for each sequence-target pair, the scores associated to the successive insertions.
+
+    An attribution method is considered good if the AUC is low, meaning that the model's prediction score decreases
+    significantly as the most important elements are removed from the sequence. Conversely, a high AUC indicates that
+    the attribution method is not effective in identifying the most important elements for the model's prediction.
+
+    This metric only evaluates the order of importance of the elements in the sequence, not their actual values.
+
+    Examples:
+        >>> from interpreto.attributions.metrics import Deletion
+        >>>
+        >>> # Get explanations from an attribution method
+        >>> explainer = Method(model, tokenizer, kwargs)
+        >>> explanations = explainer(inputs, targets)
+        >>>
+        >>> # Run the deletion metric
+        >>> metric = Deletion(model, tokenizer, n_perturbations=100)
+        >>> auc, metric_scores = metric.evaluate(explanations)
+
+    Args:
+        model (PreTrainedModel): model used to generate explanations
+        tokenizer (PreTrainedTokenizer): Hugging Face tokenizer associated with the model
+        batch_size (int): batch size for the inference of the metric
+        granularity (Granularity): granularity level of the perturbations (token, word, sentence, etc.)
+        device (torch.device): device on which the attribution method will be run
+        n_perturbations (int): number of perturbations from which the metric will be computed (i.e. the number of
+            steps from which the AUC will be computed).
+        max_percentage_perturbed (float): maximum percentage of elements in the sequence to be perturbed. Defaults
+            to 1.0, meaning that all elements can be perturbed. If set to 0.5, only half of the elements will be
+            perturbed (i.e. only the 50% most important). This is useful to avoid perturbing too many elements with
+            low scores in long sequences.
+    """
+
+    @property
+    def _perturbator_class(self) -> Callable:
+        """Return the perturbator class used for deletion."""
+        return DeletionPerturbator

--- a/interpreto/attributions/perturbations/__init__.py
+++ b/interpreto/attributions/perturbations/__init__.py
@@ -24,6 +24,7 @@
 
 from .base import TokenMaskBasedPerturbator
 from .gaussian_noise_perturbation import GaussianNoisePerturbator
+from .insertion_deletion_perturbation import DeletionPerturbator, InsertionPerturbator
 from .linear_interpolation_perturbation import LinearInterpolationPerturbator
 from .occlusion_perturbation import OcclusionPerturbator
 from .random_perturbation import RandomMaskedTokenPerturbator

--- a/interpreto/attributions/perturbations/base.py
+++ b/interpreto/attributions/perturbations/base.py
@@ -130,7 +130,7 @@ class Perturbator:
     #     """
 
     # @allow_nested_iterables_of(MutableMapping)
-    def perturb(self, inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
+    def perturb(self, inputs: TensorMapping, **kwargs) -> tuple[TensorMapping, torch.Tensor | None]:
         """
         Method called when we ask the perturbator to perturb a mapping of tensors, generally the output of a tokenizer
         The mapping should be similar to mappings returned by the tokenizer.
@@ -140,11 +140,21 @@ class Perturbator:
 
         Args:
             inputs (TensorMapping): output of the tokenizers
+            kwargs: additional arguments, used in the get_mask() method for token perturbation.
         """
         mask = None
         if "input_ids" in inputs:
             # Call the tokens perturbation on the inputs ids
-            inputs, mask = self.perturb_ids(inputs)
+            inputs, mask = self.perturb_ids(inputs, **kwargs)
+
+        # If kwargs are provided in `get_mask`, we assume that the perturbation is only performed on tokens and not on
+        # embeddings. kwargs for embeddings perturbation is not yet implemented.
+        if kwargs != {}:
+            try:
+                self.perturb_embeds(None)  # Just to check if the method is implemented or not
+                raise ValueError("kwargs in `perturb` are not yet supported for `perturb_embeds` method.") from None
+            except NotImplementedError:
+                pass
 
         try:
             # TODO : perform smart combination of perturbation masks on ids and on embeddings !
@@ -246,7 +256,7 @@ class TokenMaskBasedPerturbator(MaskBasedPerturbator):
 
     @jaxtyped(typechecker=beartype)
     @abstractmethod
-    def get_mask(self, mask_dim: int) -> Float[torch.Tensor, "{self.n_perturbations} {mask_dim}"]:
+    def get_mask(self, mask_dim: int, **kwargs) -> Float[torch.Tensor, "{self.n_perturbations} {mask_dim}"]:
         """
         Method returning a perturbation mask for a given set of inputs
         This method should be implemented in subclasses
@@ -256,18 +266,20 @@ class TokenMaskBasedPerturbator(MaskBasedPerturbator):
 
         Args:
             mask_dim (int): length of the sequence according to the granularity level
+            kwargs: additional arguments if needed by the specific implementation of the mask
 
         Returns:
             torch.Tensor: mask to apply on the inputs, of shape (n_perturbations, mask_dim)
         """
         raise NotImplementedError()
 
-    def perturb_ids(self, model_inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
+    def perturb_ids(self, model_inputs: TensorMapping, **kwargs) -> tuple[TensorMapping, torch.Tensor | None]:
         """
         Method called to perturb the inputs of the model
 
         Args:
             model_inputs (MutableMapping): mapping given by the tokenizer
+            kwargs: additional arguments, used in the get_mask() method
 
         Returns:
             tuple: model_inputs with perturbations and the specific granularity mask
@@ -289,7 +301,7 @@ class TokenMaskBasedPerturbator(MaskBasedPerturbator):
         )
 
         # compute granularity-wise perturbation mask based on the length of the sequence (granularity-wise)
-        gran_mask: Float[torch.Tensor, "p g"] = self.get_mask(association_matrix.shape[0]).to(self.device)
+        gran_mask: Float[torch.Tensor, "p g"] = self.get_mask(association_matrix.shape[0], **kwargs).to(self.device)
 
         # compute real perturbation mask
         real_mask: Float[torch.Tensor, "p l"] = torch.einsum("pg,gl->pl", gran_mask, association_matrix)

--- a/interpreto/attributions/perturbations/insertion_deletion_perturbation.py
+++ b/interpreto/attributions/perturbations/insertion_deletion_perturbation.py
@@ -1,0 +1,146 @@
+# MIT License
+#
+# Copyright (c) 2025 IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL and FOR are research programs operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Pertubation for the insertion and deletion metric.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+import numpy as np
+import torch
+from beartype import beartype
+from jaxtyping import Float, jaxtyped
+from transformers.tokenization_utils import PreTrainedTokenizer
+
+from interpreto.attributions.perturbations.base import TokenMaskBasedPerturbator
+from interpreto.commons.granularity import Granularity
+
+
+class InsertionDeletionPerturbator(TokenMaskBasedPerturbator):
+    """
+    Basic class for insertion and deletion perturbations.
+
+    The perturbations are based on the importance of the attributions: the most important elements are perturbed first
+    (inserted for Insertion or removed for Deletion). The perturbations are done iteratively, where at each step the
+    next perturbation is applied to the next most important elements in the input sequence.
+
+    Unlike standard perturbations, the perturbations are different for each target, as the perturbations are based on
+    the importance of the attributions. For `t` targets and `p` perturbations per target, the `get_mask` method returns
+    a mask of shape `(p * t, mask_dim)`, where `mask_dim` is the length of the input sequence. The first `p` rows
+    correspond to the first target, the next `p` rows to the second target, and so on.
+    """
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizer | None = None,
+        inputs_embedder: torch.nn.Module | None = None,
+        granularity: Granularity = Granularity.TOKEN,
+        n_perturbations: int = 100,
+        max_percentage_perturbed: float = 1.0,
+        replace_token_id: int = 0,
+    ) -> None:
+        """Instantiates the perturbator.
+
+        Args:
+            tokenizer (PreTrainedTokenizer | None): Hugging Face tokenizer associated with the model.
+            inputs_embedder (torch.nn.Module | None): Optional embedder used to obtain input embeddings from input IDs.
+            granularity (Granularity): Level at which deletion should be applied.
+            n_perturbations (int): Number of perturbations to generate.
+            max_percentage_perturbed (float): Maximum percentage of tokens in the sequence to be perturbed.
+            replace_token_id (int): Token used to replace deleted elements.
+        """
+
+        if n_perturbations < 1:
+            raise ValueError("The number of perturbations must be at least 1.")
+
+        super().__init__(
+            tokenizer=tokenizer,
+            replace_token_id=replace_token_id,
+            inputs_embedder=inputs_embedder,
+            n_perturbations=n_perturbations,
+            granularity=granularity,
+        )
+        self.max_percentage_perturbed = max_percentage_perturbed
+
+    @abstractmethod
+    def _baseline_mask(self, dims) -> Float[torch.Tensor, "p l"]:
+        """Returns the baseline mask for the perturbator, i.e. a mask with all zeros for
+        deletion and a mask with all ones for insertion.
+
+        Returns:
+            torch.Tensor: Tensor of shape ``(n_perturbations, mask_dim)``
+        """
+        raise NotImplementedError()
+
+    @jaxtyped(typechecker=beartype)
+    def get_mask(self, mask_dim: int, attributions) -> Float[torch.Tensor, "p l"]:
+        """Return a mask performing single-token insertions/deletions based on the attributions.
+
+        Args:
+            mask_dim (int): Length of the input sequence.
+            attributions (SingleAttribution): the attribution tensor
+
+        Returns:
+            torch.Tensor: Tensor of shape ``(n_perturbations, mask_dim)``
+        """
+
+        if attributions.ndim == 1:
+            attributions = attributions.unsqueeze(0)
+
+        # Get indices of most important tokens
+        num_targets = attributions.shape[0]
+        most_important_idx = torch.argsort(attributions, descending=True)
+
+        # Compute the real number of perturbations "p": take the minimum between n_perturbations and the number of
+        # elements to perturb (+1 for the baseline)
+        num_elements_to_perturb = int(mask_dim * self.max_percentage_perturbed)
+        p = min(self.n_perturbations, max(num_elements_to_perturb, 1)) + 1
+
+        # Build the mask
+        mask: Float[torch.Tensor, "p l"] = self._baseline_mask((p * num_targets, mask_dim))
+        steps = np.linspace(0, max(1, num_elements_to_perturb), p)
+        fill_value = int(1 - mask[0, 0])  # Value to fill the mask with (1 for deletion, 0 for insertion)
+        for j in range(num_targets):
+            for i, step in enumerate(steps):
+                mask[(p * j) + i, most_important_idx[j, : int(step)]] = fill_value
+
+        return mask
+
+
+class DeletionPerturbator(InsertionDeletionPerturbator):
+    """Perturbator for deletion metric."""
+
+    def _baseline_mask(self, dims) -> Float[torch.Tensor, "p l"]:
+        """Return the baseline mask for the perturbator, i.e. a mask full of zeros."""
+        return torch.zeros(dims)
+
+
+class InsertionPerturbator(InsertionDeletionPerturbator):
+    """Perturbator for insertion metric."""
+
+    def _baseline_mask(self, dims) -> Float[torch.Tensor, "p l"]:
+        """Return the baseline mask for the perturbator, i.e. a mask full of ones."""
+        return torch.ones(dims)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,8 @@ nav:
         - Sobol: api/attributions/methods/sobol.md
       - Metrics:
         - Overview: api/attributions/metrics/overview.md
+        - Insertion: api/attributions/metrics/insertion.md
+        - Deletion: api/attributions/metrics/deletion.md
     - Concept Explainers:
       - Overview: api/concepts/overview.md
       - Model Wrapping: api/commons/model_wrapping.md

--- a/tests/attributions/metrics/test_insertion_deletion.py
+++ b/tests/attributions/metrics/test_insertion_deletion.py
@@ -1,0 +1,146 @@
+# MIT License
+#
+# Copyright (c) 2025 IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL and FOR are research programs operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""This test module evaluates the Insertion and Deletion metrics."""
+
+import pytest
+import torch
+
+from interpreto import Granularity, Occlusion
+from interpreto.attributions.aggregations.insertion_deletion_aggregation import InsertionDeletionAggregator
+from interpreto.attributions.metrics import Deletion, Insertion
+from interpreto.attributions.perturbations import DeletionPerturbator, InsertionPerturbator
+
+test_cases = [
+    {  # Test case 1: Insertion metric with Token granularity and 10 perturbations
+        "metric_class": Insertion,
+        "granularity": Granularity.TOKEN,
+        "n_perturbations": 10,
+        "expected_results": {
+            "perturbator_type": InsertionPerturbator,
+            "expected_auc": 0.505163,
+            "scores_shape": [(11, 1), (11, 1), (11, 1)],
+        },
+    },
+    {  # Test case 2: Deletion metric with Token granularity and 50 perturbations
+        "metric_class": Deletion,
+        "granularity": Granularity.TOKEN,
+        "n_perturbations": 50,
+        "expected_results": {
+            "perturbator_type": DeletionPerturbator,
+            "expected_auc": 0.505124,
+            "scores_shape": [(51, 1), (20, 1), (18, 1)],
+        },
+    },
+    {  # Test case 3: Insertion metric with Word granularity and 5 perturbations
+        "metric_class": Insertion,
+        "granularity": Granularity.WORD,
+        "n_perturbations": 5,
+        "expected_results": {
+            "perturbator_type": InsertionPerturbator,
+            "expected_auc": 0.505147,
+            "scores_shape": [(6, 1), (4, 1), (3, 1)],
+        },
+    },
+    {  # Test case 4: Deletion metric with Word granularity and 5 perturbations
+        "metric_class": Deletion,
+        "granularity": Granularity.WORD,
+        "n_perturbations": 5,
+        "expected_results": {
+            "perturbator_type": DeletionPerturbator,
+            "expected_auc": 0.505140,
+            "scores_shape": [(6, 1), (4, 1), (3, 1)],
+        },
+    },
+]
+
+
+def id_names(param):
+    """Generate an id for each test case based on its parameter values."""
+    return (
+        param["metric_class"].__name__
+        + "-Granularity."
+        + param["granularity"].upper()
+        + "-n_perturbations="
+        + str(param["n_perturbations"])
+    )
+
+
+@pytest.fixture(params=test_cases, ids=id_names)
+def metric_test_case(request):
+    """Fixture to provide test cases for insertion and deletion metrics."""
+    return request.param
+
+
+def test_insertion_deletion_metric(bert_model, bert_tokenizer, sentences, metric_test_case):
+    """Test the insertion and deletion metrics with various configurations.
+
+    Multiple aspects are assessed:
+    - Perturbator initialization and parameters
+    - Perturbator functionality via get_mask
+    - Aggregator type and functionality
+    - AUC correctness and metric scores shape
+    """
+
+    metric_class = metric_test_case["metric_class"]
+    granularity = metric_test_case["granularity"]
+    n_perturbations = metric_test_case["n_perturbations"]
+    expected_results = metric_test_case["expected_results"]
+
+    torch.manual_seed(0)
+
+    metric = metric_class(
+        model=bert_model,
+        tokenizer=bert_tokenizer,
+        granularity=granularity,
+        n_perturbations=n_perturbations,
+    )
+
+    # Assert that the "[REPLACE]" token has correctly been added to the tokenizer
+    assert "[REPLACE]" in bert_tokenizer.get_vocab()
+
+    # Assert that the perturbator stored its params correctly
+    assert isinstance(metric.perturbator, expected_results["perturbator_type"])
+    assert metric.perturbator.n_perturbations == n_perturbations
+    assert metric.perturbator.granularity == granularity
+    replace_id = bert_tokenizer.convert_tokens_to_ids("[REPLACE]")  # the token ID should match what we just added
+    assert metric.perturbator.replace_token_id == replace_id
+
+    # Assert the aggregator type
+    assert isinstance(metric.aggregator, InsertionDeletionAggregator)
+
+    # Assert that get_mask returns a tensor of the right shape
+    seq_len = n_perturbations - 2  # to ensure we have as many perturbations as the sequence length
+    num_targets = 3
+    attributions = torch.arange(seq_len * num_targets).view(num_targets, seq_len).float()
+    mask = metric.perturbator.get_mask(seq_len, attributions=attributions)
+    assert isinstance(mask, torch.Tensor)
+    assert mask.shape == ((seq_len + 1) * num_targets, seq_len)
+
+    # Assert AUC correctness and metric scores shape using sentences from conftest
+    explainer = Occlusion(bert_model, bert_tokenizer, granularity=granularity)
+    attributions = explainer.explain(sentences)
+    auc, metric_scores = metric.evaluate(attributions)
+
+    assert auc == pytest.approx(expected_results["expected_auc"])
+    assert [s.shape for s in metric_scores] == expected_results["scores_shape"]

--- a/tests/attributions/perturbations/test_insertion_deletion_perturbator.py
+++ b/tests/attributions/perturbations/test_insertion_deletion_perturbator.py
@@ -1,0 +1,207 @@
+# MIT License
+#
+# Copyright (c) 2025 IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL and FOR are research programs operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+
+from interpreto.attributions.perturbations import DeletionPerturbator, InsertionPerturbator
+
+
+@pytest.mark.parametrize("PerturbatorClass, expected_value", [(DeletionPerturbator, 0), (InsertionPerturbator, 1)])
+def test_baseline_mask(PerturbatorClass, expected_value):
+    """Asserts that the baseline mask is initialized correctly for both insertion and
+    deletion perturbators.
+    """
+    pert = PerturbatorClass()
+    mask = pert._baseline_mask((5, 12))
+    assert mask.shape == (5, 12)
+    assert torch.all(mask == expected_value)
+
+
+@pytest.mark.parametrize("PerturbatorClass", [DeletionPerturbator, InsertionPerturbator])
+def test_get_mask_single_target(PerturbatorClass):
+    """Asserts that the get_mask method generates the correct mask for insertion and deletion perturbators.
+
+    This test focuses on perturbations for a single target.
+    Several scenarios are tested: different numbers of perturbations and values of max_percentage_perturbed.
+    """
+
+    attributions = torch.tensor([0.1, 0.4, 0.2, 0.8, 0.3])  # length: 5
+    mask_dim = len(attributions)
+
+    # Test 1: the number of perturbations is equal mask_dim (+ 1 for the baseline).
+    perturbator = PerturbatorClass(n_perturbations=mask_dim)
+
+    mask = perturbator.get_mask(mask_dim, attributions)
+
+    expected_mask = torch.Tensor(
+        [
+            [0, 0, 0, 0, 0],  # baseline
+            [0, 0, 0, 1, 0],
+            [0, 1, 0, 1, 0],
+            [0, 1, 0, 1, 1],
+            [0, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1],
+        ]
+    )
+    if PerturbatorClass.__name__ == "InsertionPerturbator":
+        expected_mask = 1 - expected_mask
+
+    assert isinstance(mask, torch.Tensor)
+    assert mask.shape == (mask_dim + 1, mask_dim)  # (mask_dim + 1) for the baseline mask
+    assert (mask == expected_mask).all()
+
+    # Test 2: the number of perturbations is more than mask_dim + 1.
+    perturbator = PerturbatorClass(n_perturbations=10)
+    mask = perturbator.get_mask(mask_dim, attributions)
+    assert mask.shape == (mask_dim + 1, mask_dim)
+
+    # Test 3: the number of perturbations is less than mask_dim + 1.
+    perturbator = PerturbatorClass(n_perturbations=3)
+    mask = perturbator.get_mask(mask_dim, attributions)
+    assert mask.shape == (3 + 1, mask_dim)
+
+    # Test 4: the number of perturbations is equal to 1.
+    perturbator = PerturbatorClass(n_perturbations=1)
+    mask = perturbator.get_mask(mask_dim, attributions)
+    assert mask.shape == (1 + 1, mask_dim)
+    assert (mask[0] == expected_mask[0]).all(), "First perturbation should be the baseline mask."
+    assert (mask[1] == expected_mask[-1]).all(), "Second perturbation should be the full mask."
+
+    # Test 5: max percentage perturbed at 50% (i.e. half of mask_dim).
+    perturbator = PerturbatorClass(n_perturbations=10, max_percentage_perturbed=0.5)
+    mask = perturbator.get_mask(mask_dim, attributions)
+    assert mask.shape == (3, mask_dim)  # int(0.5 * mask_dim) + 1 = 3 perturbations
+
+
+@pytest.mark.parametrize("PerturbatorClass", [DeletionPerturbator, InsertionPerturbator])
+def test_get_mask_multiple_targets(PerturbatorClass):
+    """Asserts that the get_mask method generates the correct masks for insertion and deletion perturbators
+    with multiple targets.
+
+    Three scenarios are tested: 1) the number of perturbations is equal to the number of elements (+ 1 for the
+    baseline), 2) the number of perturbations is less than the number of elements, and 3) perturb only 50% of the
+    elements.
+    """
+
+    attributions = torch.tensor(  # shape: (2, 6) => 2 targets, 6 elements
+        [
+            [0.1, 0.3, 0.2, 0.9, 0.4, 0.8],  # order: [3, 5, 4, 1, 2, 0]
+            [-0.1, -0.8, -0.9, -0.2, -1.5, -1.6],  # order: [0, 3, 1, 2, 4, 5]
+        ]
+    )
+    num_targets, mask_dim = attributions.shape
+
+    # Test 1: the number of perturbations is equal to mask_dim (+ 1 for the baseline).
+    perturbator = PerturbatorClass(n_perturbations=mask_dim)
+    mask = perturbator.get_mask(mask_dim, attributions)
+
+    expected_mask = torch.Tensor(
+        [
+            # Perturbations for target 0
+            [0, 0, 0, 0, 0, 0],  # baseline
+            [0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0, 1],
+            [0, 0, 0, 1, 1, 1],
+            [0, 1, 0, 1, 1, 1],
+            [0, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1],
+            # Perturbations for target 1
+            [0, 0, 0, 0, 0, 0],  # baseline
+            [1, 0, 0, 0, 0, 0],
+            [1, 0, 0, 1, 0, 0],
+            [1, 1, 0, 1, 0, 0],
+            [1, 1, 1, 1, 0, 0],
+            [1, 1, 1, 1, 1, 0],
+            [1, 1, 1, 1, 1, 1],
+        ]
+    )
+    if PerturbatorClass.__name__ == "InsertionPerturbator":
+        expected_mask = 1 - expected_mask
+
+    assert mask.shape == (num_targets * (mask_dim + 1), mask_dim)
+    assert (mask == expected_mask).all()
+
+    # Test 2: the number of perturbations is half of mask_dim
+    perturbator = PerturbatorClass(n_perturbations=mask_dim // 2)
+    mask = perturbator.get_mask(mask_dim, attributions)
+
+    expected_mask = torch.Tensor(
+        [
+            # Perturbations for target 0
+            [0, 0, 0, 0, 0, 0],  # baseline
+            [0, 0, 0, 1, 0, 1],
+            [0, 1, 0, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1],
+            # Perturbations for target 1
+            [0, 0, 0, 0, 0, 0],  # baseline
+            [1, 0, 0, 1, 0, 0],
+            [1, 1, 1, 1, 0, 0],
+            [1, 1, 1, 1, 1, 1],
+        ]
+    )
+    if PerturbatorClass.__name__ == "InsertionPerturbator":
+        expected_mask = 1 - expected_mask
+
+    assert mask.shape == (num_targets * (mask_dim // 2 + 1), mask_dim)  # (2*4, 6)
+    assert (mask == expected_mask).all()
+
+    # Test 3: perturb only 50% of the elements: the first 3 most important elements for each target.
+    perturbator = PerturbatorClass(n_perturbations=100, max_percentage_perturbed=0.5)
+    mask = perturbator.get_mask(mask_dim, attributions)
+
+    expected_mask = torch.Tensor(
+        [
+            # Perturbations for target 0
+            [0, 0, 0, 0, 0, 0],  # baseline
+            [0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0, 1],
+            [0, 0, 0, 1, 1, 1],
+            # Perturbations for target 1
+            [0, 0, 0, 0, 0, 0],  # baseline
+            [1, 0, 0, 0, 0, 0],
+            [1, 0, 0, 1, 0, 0],
+            [1, 1, 0, 1, 0, 0],
+        ]
+    )
+    if PerturbatorClass.__name__ == "InsertionPerturbator":
+        expected_mask = 1 - expected_mask
+
+    assert mask.shape == (num_targets * (mask_dim // 2 + 1), mask_dim)  # (2*4, 6)
+    assert (mask == expected_mask).all()
+
+
+def test_invalid_perturbation_count():
+    """Asserts that a ValueError is raised when the number of perturbations is less than 1."""
+    with pytest.raises(ValueError, match="The number of perturbations must be at least 1."):
+        DeletionPerturbator(n_perturbations=0)
+
+
+def test_max_percentage_perturbed_zero():
+    """Asserts that the max_percentage_perturbed parameter works correctly when set to zero."""
+    # Max 0% -> still generates at least 2 perturbations
+    perturbator = InsertionPerturbator(n_perturbations=10, max_percentage_perturbed=0.0)
+    attributions = torch.rand(10)
+    mask = perturbator.get_mask(mask_dim=10, attributions=attributions)
+    assert mask.shape == (2, 10), "Should still generate at least 2 perturbations"

--- a/tests/visualizations/test_attributions.py
+++ b/tests/visualizations/test_attributions.py
@@ -15,7 +15,12 @@ def test_attribution_monoclass():
     sentence = ["A", "B", "C", "one", "two", "three"]
     attributions = torch.linspace(-10, 10, steps=len(sentence))
     single_class_classification_output = AttributionOutput(
-        elements=sentence, attributions=attributions, model_task=ModelTask.SINGLE_CLASS_CLASSIFICATION, classes=[0]
+        elements=sentence,
+        attributions=attributions,
+        model_task=ModelTask.SINGLE_CLASS_CLASSIFICATION,
+        classes=[0],
+        model_inputs_to_explain={},  # dummy, not used in visualization
+        targets=torch.Tensor(),  # dummy, not used in visualization
     )
 
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -43,7 +48,12 @@ def test_attribution_multiclass():
 
     attributions = torch.rand(nb_classes, len(sentence))  # (c, l)
     multi_class_classification_output = AttributionOutput(
-        elements=sentence, attributions=attributions, model_task=ModelTask.MULTI_CLASS_CLASSIFICATION, classes=[0, 1]
+        elements=sentence,
+        attributions=attributions,
+        model_task=ModelTask.MULTI_CLASS_CLASSIFICATION,
+        classes=[0, 1],
+        model_inputs_to_explain={},  # dummy, not used in visualization
+        targets=torch.Tensor(),  # dummy, not used in visualization
     )
 
     viz = AttributionVisualization(
@@ -73,7 +83,13 @@ def test_attribution_generation():
 
     def make_attributions_outputs(inputs, outputs):
         attributions = torch.rand(len(outputs), len(inputs) + len(outputs))  # (l_g, l)
-        return AttributionOutput(elements=inputs + outputs, attributions=attributions, model_task=ModelTask.GENERATION)
+        return AttributionOutput(
+            elements=inputs + outputs,
+            attributions=attributions,
+            model_task=ModelTask.GENERATION,
+            model_inputs_to_explain={},  # dummy, not used in visualization
+            targets=torch.Tensor(),  # dummy, not used in visualization
+        )
 
     generation_output = make_attributions_outputs(inputs_sentence, outputs_sentence)
 
@@ -104,7 +120,13 @@ def test_concepts():
 
     def make_attributions_outputs(inputs, outputs):
         attributions = torch.rand(len(inputs) + len(outputs), len(outputs), nb_concepts)  # (l, l_g, c)
-        return AttributionOutput(elements=inputs + outputs, attributions=attributions, model_task=ModelTask.GENERATION)
+        return AttributionOutput(
+            elements=inputs + outputs,
+            attributions=attributions,
+            model_task=ModelTask.GENERATION,
+            model_inputs_to_explain={},  # dummy, not used in visualization
+            targets=torch.Tensor(),  # dummy, not used in visualization
+        )
 
     generation_output = make_attributions_outputs(inputs_sentence, outputs_sentence)
     colors_set1 = plt.get_cmap("Set1").colors


### PR DESCRIPTION
## Description

This PR introduces the Insertion and Deletion metrics for attribution methods. It includes the following new features:
- new `InsertionPerturbator` and `DeletionPerturbator` that perturbs the inputs based on the order of importance of the tokens. The importance is given by the attribution scores. The Perturbators return masks where elements are iteratively inserted/removed based on the importance.
- new `InsertionDeletionAggregator` that reformats scores obtained from the perturbed sequences in order to compute the metric AUC.
- the new metrics: `Insertion` and `Deletion`. They are built as an AttributionExplainer with custom perturbator and aggregator (defined above). These new classes return an average AUC score and the raw scores for each sequence with the successive perturbations. The raw scores are useful to plot the curve on which the AUC score is computed.
- Unit tests are added for these new classes.

For a seamless integration, two changes are proposed:
- the `AttributionOutput` was extended to store the "model_inputs_to_explain", the targets, the granularity and the inference mode.
- the base `Perturbator` now accepts kwargs that are transferred to the `get_mask` method. This is required to give the attribution outputs to `get_mask` in order to compute the mask based on the importance of the attributions.

Finally, some bugs are fixed:
- in attribution methods, `tokenizer` is replaced with `self.tokenizer` to avoid confusion on possible different objects.
- in Occlusion method, `replace_token_id` argument was removed since it is now retrieved from the tokenizer, as done in other methods. The behaviour is now unified across methods.

## Type of Change

- 📚 Examples / docs / tutorials / dependencies update
- 🔧 Bug fix (non-breaking change which fixes an issue)
- 🚀 New feature (non-breaking change which adds functionality)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
