### PR TITLE
Interpretations refacto

### DIFF
--- a/docs/api/concepts/interpretations/llm_labels.md
+++ b/docs/api/concepts/interpretations/llm_labels.md
@@ -20,3 +20,9 @@ icon: material/robot-outline
       inherited_members: true
       members:
         - generate
+
+::: interpreto.concepts.interpretations.extract_unique_words
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: true

--- a/docs/api/concepts/interpretations/llm_labels.md
+++ b/docs/api/concepts/interpretations/llm_labels.md
@@ -1,9 +1,9 @@
 ---
-icon: material/keyboard-tab-reverse
+icon: material/robot-outline
 ---
 
 
-::: interpreto.concepts.interpretations.TopKInputs
+::: interpreto.concepts.interpretations.LLMLabels
     handler: python
     options:
       show_root_heading: true
@@ -12,8 +12,11 @@ icon: material/keyboard-tab-reverse
       members:
         - interpret
 
-::: interpreto.concepts.interpretations.extract_unique_words
+::: interpreto.model_wrapping.llm_interface.LLMInterface
     handler: python
     options:
       show_root_heading: true
       show_source: true
+      inherited_members: true
+      members:
+        - generate

--- a/docs/api/concepts/overview.md
+++ b/docs/api/concepts/overview.md
@@ -33,7 +33,7 @@ concept_explainer = ICAConcepts(model_with_split_points)
 concept_explainer.fit(activations)
 
 # 5. Interpret the obtained concepts
-interpretation = concept_explainer.interpret(TopKInputs, inputs=dataset)
+interpretation = TopKInputs(concept_explainer).interpret(dataset)
 
 # 6. Evaluate concepts' contributions to the output
 concept_gradients = concept_explainer.concept_output_gradient(inputs=dataset)

--- a/interpreto/concepts/base.py
+++ b/interpreto/concepts/base.py
@@ -32,7 +32,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from functools import wraps
 from textwrap import dedent
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, TypeVar
 
 import torch
 from jaxtyping import Float
@@ -40,7 +40,6 @@ from overcomplete.base import BaseDictionaryLearning
 from transformers.tokenization_utils_base import BatchEncoding
 
 from interpreto.attributions.base import AttributionExplainer
-from interpreto.concepts.interpretations.base import BaseConceptInterpretationMethod
 from interpreto.model_wrapping.model_with_split_points import (
     ActivationGranularity,
     GranularityAggregationStrategy,
@@ -209,60 +208,18 @@ class ConceptEncoderExplainer(ABC, Generic[ConceptModel]):
         return self._sanitize_activations(activations)
 
     @check_fitted
-    def interpret(
-        self,
-        interpretation_method: type[BaseConceptInterpretationMethod],
-        concepts_indices: int | list[int] | Literal["all"],
-        inputs: list[str] | None = None,
-        latent_activations: dict[str, LatentActivations] | LatentActivations | None = None,
-        concepts_activations: ConceptsActivations | None = None,
-        **kwargs,
-    ) -> Mapping[int, Any]:
+    def interpret(self, *args, **kwargs) -> Mapping[int, Any]:
+        """Deprecated API for concept interpretation.
+
+        Interpretation methods should now be instantiated directly with the
+        fitted concept explainer. For example:
+
+        ``TopKInputs(concept_explainer).interpret(inputs, latent_activations)``
+
+        This method is kept only for backwards compatibility and will always
+        raise a :class:`NotImplementedError`.
         """
-        Interpret the concepts dimensions in the latent space into a human-readable format.
-        The interpretation is a mapping between the concepts indices and an object allowing to interpret them.
-        It can be a label, a description, examples, etc.
-
-        Args:
-            interpretation_method: The interpretation method to use to interpret the concepts.
-            concepts_indices (int | list[int] | Literal["all"]): The indices of the concepts to interpret.
-                If "all", all concepts are interpreted.
-            inputs (list[str] | None): The inputs to use for the interpretation.
-                Necessary if the source is not `VOCABULARY`, as examples are extracted from the inputs.
-            latent_activations (LatentActivations | dict[str, LatentActivations] | None): The latent activations to use for the interpretation.
-                Necessary if the source is `LATENT_ACTIVATIONS`.
-                Otherwise, it is computed from the inputs or ignored if the source is `CONCEPT_ACTIVATIONS`.
-            concepts_activations (ConceptsActivations | None): The concepts activations to use for the interpretation.
-                Necessary if the source is not `CONCEPT_ACTIVATIONS`. Otherwise, it is computed from the latent activations.
-            **kwargs: Additional keyword arguments to pass to the interpretation method.
-
-        Returns:
-            Mapping[int, Any]: A mapping between the concepts indices and the interpretation of the concepts.
-        """
-        if concepts_indices == "all":
-            concepts_indices = list(range(self.concept_model.nb_concepts))
-
-        # verify
-        if latent_activations is not None:
-            split_latent_activations = self._sanitize_activations(latent_activations)
-        else:
-            split_latent_activations = None
-
-        # initialize the interpretation method
-        method = interpretation_method(
-            model_with_split_points=self.model_with_split_points,
-            split_point=self.split_point,
-            concept_model=self.concept_model,
-            **kwargs,
-        )
-
-        # compute the interpretation from inputs and activations
-        return method.interpret(
-            concepts_indices=concepts_indices,
-            inputs=inputs,
-            latent_activations=split_latent_activations,
-            concepts_activations=concepts_activations,
-        )
+        raise NotImplementedError("Use the new API: TopKInputs(concept_explainer).interpret(...).")
 
     @check_fitted
     def input_concept_attribution(

--- a/interpreto/concepts/interpretations/__init__.py
+++ b/interpreto/concepts/interpretations/__init__.py
@@ -22,7 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from .base import extract_unique_words
 from .llm_labels import LLMLabels
-from .topk_inputs import TopKInputs, extract_unique_words
+from .topk_inputs import TopKInputs
 
 __all__ = ["TopKInputs", "LLMLabels", "extract_unique_words"]

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -114,7 +114,7 @@ def extract_unique_words(
         for word in word_tokenize(text):
             # lemmatize words
             if lemmatize:
-                word = lemmatizer.lemmatize(word.lower())  # type: ignore  (ignore possibly unbound)
+                word = lemmatizer.lemmatize(word.lower())  # noqa: PLW2901  # type: ignore  (ignore possibly unbound)
 
             # ignore words
             if words_to_ignore is not None and word in words_to_ignore:

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -233,9 +233,6 @@ class BaseConceptInterpretationMethod(ABC):
         if use_unique_words and use_vocab:
             raise ValueError("Cannot use both `use_unique_words` and `use_vocab`. Please use only one of them.")
 
-        if activation_granularity == ActivationGranularity.CLS_TOKEN and not use_unique_words:
-            raise ValueError("Cannot use `activation_granularity` CLS_TOKEN without `use_unique_words` set to True.")
-
         self.concept_explainer: ConceptEncoderExplainer = concept_explainer
         self.activation_granularity: ActivationGranularity = activation_granularity
         self.concept_encoding_batch_size: int = concept_encoding_batch_size

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -196,13 +196,15 @@ class BaseConceptInterpretationMethod(ABC):
             If False, the granular inputs are extracted from the inputs.
 
         use_unique_words (bool):
-            Whether to use unique words to extract the granular inputs.
-            If True, the granular inputs are extracted from the unique words in the inputs.
-            If False, the granular inputs are extracted from the inputs.
+            If True, the interpretation will be computed from the unique words of the inputs.
+            Incompatible with `use_vocab=True`.
+            Default unique words selects all different word from the input.
+            It can be tuned through the `unique_words_kwargs` argument.
 
         unique_words_kwargs (dict):
             The kwargs to pass to the `extract_unique_words` function.
             see `interpreto.concepts.interpretations.topk_inputs.extract_unique_words` for more details.
+            Possible arguments are `count_min_threshold`, `lemmatize`, `words_to_ignore`.
 
         device (torch.device | str | None):
             The device to use for the interpretation.

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -216,7 +216,6 @@ class BaseConceptInterpretationMethod(ABC):
         self.use_vocab: bool = use_vocab
         self.use_unique_words: bool = use_unique_words
         self.device: torch.device | str | None = device
-        self.__call__ = self.interpret
 
     @abstractmethod
     def interpret(

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -181,6 +181,31 @@ class BaseConceptInterpretationMethod(ABC):
     Its goal is to make the dimensions of the concept space interpretable by humans.
 
     Attributes:
+        concept_explainer (ConceptEncoderExplainer):
+            The concept explainer used to compute the concept activations.
+
+        activation_granularity (ActivationGranularity):
+            The granularity of the activations to use for the interpretation.
+
+        concept_encoding_batch_size (int):
+            The batch size to use for the concept encoding.
+
+        use_vocab (bool):
+            Whether to use the vocabulary to extract the granular inputs.
+            If True, the granular inputs are extracted from the vocabulary.
+            If False, the granular inputs are extracted from the inputs.
+
+        use_unique_words (bool):
+            Whether to use unique words to extract the granular inputs.
+            If True, the granular inputs are extracted from the unique words in the inputs.
+            If False, the granular inputs are extracted from the inputs.
+
+        unique_words_kwargs (dict):
+            The kwargs to pass to the `extract_unique_words` function.
+            see `interpreto.concepts.interpretations.topk_inputs.extract_unique_words` for more details.
+
+        device (torch.device | str | None):
+            The device to use for the interpretation.
     """
 
     def __init__(
@@ -190,6 +215,7 @@ class BaseConceptInterpretationMethod(ABC):
         concept_encoding_batch_size: int = 1024,
         use_vocab: bool = False,
         use_unique_words: bool = False,
+        unique_words_kwargs: dict = {},
         device: torch.device | str | None = "cpu",
     ):
         if activation_granularity not in (
@@ -215,6 +241,7 @@ class BaseConceptInterpretationMethod(ABC):
         self.concept_encoding_batch_size: int = concept_encoding_batch_size
         self.use_vocab: bool = use_vocab
         self.use_unique_words: bool = use_unique_words
+        self.unique_words_kwargs: dict = unique_words_kwargs
         self.device: torch.device | str | None = device
 
     @abstractmethod
@@ -365,7 +392,7 @@ class BaseConceptInterpretationMethod(ABC):
                 - list[str]: The granular texts from the inputs, flattened
                 - list[int]: The sample id for each granular text, to keep track of which sample the text belongs to.
         """
-        if self.activation_granularity is ActivationGranularity.SAMPLE:
+        if self.activation_granularity in (ActivationGranularity.SAMPLE, ActivationGranularity.CLS_TOKEN):
             # no activation_granularity is needed
             return inputs, list(range(len(inputs)))
 
@@ -451,7 +478,9 @@ class BaseConceptInterpretationMethod(ABC):
                 # ----------------------------------------------------------------------------------
                 # Case 2: use_unique_words=True
                 # first list unique words from the inputs and compute the activations from them
-                granular_inputs: list[str] = extract_unique_words(inputs=inputs, return_counts=False)  # type: ignore  (sure list[str] with return_counts=False)
+                granular_inputs: list[str] = extract_unique_words(
+                    inputs=inputs, return_counts=False, **self.unique_words_kwargs
+                )  # type: ignore  (sure list[str] with return_counts=False)
                 if latent_activations is not None and concepts_activations is not None:
                     warnings.warn(
                         "`latent_activations` or `concepts_activations` were provided, "

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -28,224 +28,109 @@ Base class for concept interpretation methods.
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
+import nltk
 import torch
-from jaxtyping import Float
+from beartype import beartype
+from jaxtyping import Float, jaxtyped
+from nltk.stem import WordNetLemmatizer
+from nltk.tokenize import word_tokenize
 
 from interpreto import Granularity, ModelWithSplitPoints
+from interpreto.concepts.base import ConceptEncoderExplainer
 from interpreto.model_wrapping.model_with_split_points import ActivationGranularity
-from interpreto.typing import ConceptModelProtocol, ConceptsActivations, LatentActivations
+from interpreto.typing import ConceptsActivations, LatentActivations
 
 
-class BaseConceptInterpretationMethod(ABC):
-    """Code: [:octicons-mark-github-24: `concepts/interpretations/base.py` ](https://github.com/FOR-sight-ai/interpreto/blob/dev/interpreto/concepts/interpretations/base.py)
-
-    Abstract class defining an interface for concept interpretation.
-    Its goal is to make the dimensions of the concept space interpretable by humans.
-
-    Attributes:
+@jaxtyped(typechecker=beartype)
+def extract_unique_words(
+    inputs: list[str],
+    count_min_threshold: int = 1,
+    return_counts: bool = False,
+    lemmatize: bool = False,
+    words_to_ignore: list[str] | None = None,
+) -> list[str] | Counter[str]:
     """
+    Extract words from a text.
 
-    def __init__(
-        self,
-        model_with_split_points: ModelWithSplitPoints,
-        concept_model: ConceptModelProtocol,
-        activation_granularity: ActivationGranularity,
-        split_point: str | None = None,
-        concept_encoding_batch_size: int = 1024,
-        device: torch.device | str | None = "cpu",
-    ):
-        if not hasattr(concept_model, "encode"):
-            raise TypeError(
-                f"Concept model should be able to encode activations into concepts. Got: {type(concept_model)}."
-            )
+    Depending on parameters, it may select a subset of words or return the counts of each word.
 
-        if split_point is None:
-            if len(model_with_split_points.split_points) > 1:
-                raise ValueError(
-                    "If the model has more than one split point, a split point for fitting the concept model should "
-                    f"be specified. Got split point: '{split_point}' with model split points: "
-                    f"{', '.join(model_with_split_points.split_points)}."
-                )
-            split_point = model_with_split_points.split_points[0]
+    Args:
+        inputs (str):
+            The text to extract words from.
 
-        if split_point not in model_with_split_points.split_points:
-            raise ValueError(
-                f"Split point '{split_point}' not found in model split points: "
-                f"{', '.join(model_with_split_points.split_points)}."
-            )
+        count_min_threshold (float, optional):
+            The minimum total number of a occurrence of a word in the whole `inputs`.
 
-        self.model_with_split_points: ModelWithSplitPoints = model_with_split_points
-        self.split_point: str = split_point
-        self.concept_model: ConceptModelProtocol = concept_model
-        self.activation_granularity: ActivationGranularity = activation_granularity
-        self.concept_encoding_batch_size: int = concept_encoding_batch_size
-        self.device: torch.device | str | None = device
+        return_counts (bool, optional):
+            Whether to return the counts of each word.
+            Defaults to False.
 
-    @abstractmethod
-    def interpret(
-        self,
-        concepts_indices: int | list[int],
-        inputs: list[str] | None = None,
-        latent_activations: LatentActivations | None = None,
-        concepts_activations: ConceptsActivations | None = None,
-    ) -> Mapping[int, Any]:
-        """
-        Interpret the concepts dimensions in the latent space into a human-readable format.
-        The interpretation is a mapping between the concepts indices and an object allowing to interpret them.
-        It can be a label, a description, examples, etc.
+        words_to_ignore: (list[str], optional):
+            A list of words to ignore.
 
-        Args:
-            concepts_indices (int | list[int]): The indices of the concepts to interpret.
-            inputs (ModelInput | None): The inputs to use for the interpretation.
-            latent_activations (LatentActivations | None): The latent activations to use for the interpretation.
-            concepts_activations (ConceptsActivations | None): The concepts activations to use for the interpretation.
+    Examples:
+        Fastest version as used in `TopKInputs`.
+        >>> extract_unique_words(["Interpreto is the latin for 'to interpret'.", "interpreto is magic"])
+        ["interpreto", "is", "the", "latin", "for", "to", "'", "interpret", ".", "magic"]
 
-        Returns:
-            Mapping[int, Any]: The interpretation of each of the specified concepts.
-        """
-        raise NotImplementedError
+        More complex use:
+        >>> from datasets import load_dataset
+        >>> from nltk.corpus import stopwords
+        >>> from interpreto.concepts.interpretations.topk_inputs import extract_unique_words
+        >>> dataset = load_dataset("cornell-movie-review-data/rotten_tomatoes")["train"]["text"]
+        >>> extract_unique_words(
+        ...     inputs=dataset,
+        ...     count_min_threshold=20,
+        ...     return_counts=True,
+        ...     lemmatize=True,
+        ...     words_to_ignore=stopwords.words("english"),
+        ... )
+        Counter(TODO)
 
-    def concepts_activations_from_source(
-        self,
-        *,
-        inputs: list[str] | None = None,
-        latent_activations: Float[torch.Tensor, "nl d"] | None = None,
-        concepts_activations: Float[torch.Tensor, "nl cpt"] | None = None,
-    ) -> Float[torch.Tensor, "nl cpt"]:
-        """
-        Computes the concepts activations from the given samples.
-        Samples can be provided as raw text (`inputs`), latent activations (`latent_activations`),
-        or directly concept activations (`concepts_activations`).
+    Returns:
+        list[str] | Counter[str]:
+            The list of unique words or the counts of each word.
 
-        Args:
-            inputs (list[str] | None): The indices of the concepts to interpret.
-            latent_activations (Float[torch.Tensor, "nl d"] | None): The latent activations
-            concepts_activations (Float[torch.Tensor, "nl cpt"] | None): The concepts activations
+    Raises:
+        ValueError:
+            If the input is not a list of strings.
+    """
+    nltk.download("wordnet")
+    nltk.download("punkt")
+    nltk.download("punkt_tab")
+    if lemmatize:
+        lemmatizer = WordNetLemmatizer()
 
-        Returns:
-            Float[torch.Tensor, "nl cpt"] :
-        """
+    # counter both list unique words and counts of each word
+    words_count = Counter()
 
-        if concepts_activations is not None:
-            return concepts_activations
+    for text in inputs:
+        for word in word_tokenize(text):
+            # lemmatize words
+            if lemmatize:
+                word = lemmatizer.lemmatize(word.lower())  # type: ignore  (ignore possibly unbound)
 
-        if latent_activations is not None:
-            # TODO: remove the if case when all overcomplete models are nn modules
-            if hasattr(self.concept_model, "to") and self.device is not None:
-                self.concept_model.to(self.device)  # type: ignore
+            # ignore words
+            if words_to_ignore is not None and word in words_to_ignore:
+                continue
 
-            # batch over latent activations for concept encoding
-            concepts_activations_list = []
-            for batch_idx in range(0, latent_activations.shape[0], self.concept_encoding_batch_size):
-                # extract and encode a batch of latent activations
-                batch_latent_activations = latent_activations[batch_idx : batch_idx + self.concept_encoding_batch_size]
+            # add word to counter
+            words_count[word] += 1
 
-                if hasattr(batch_latent_activations, "to"):
-                    batch_latent_activations = batch_latent_activations.to(self.device)  # type: ignore
-                batch_concepts_activations = self.concept_model.encode(batch_latent_activations)
+    # filter too rare words
+    if count_min_threshold > 1:
+        words_count = Counter({key: count for key, count in words_count.items() if count >= count_min_threshold})
 
-                # SAEs outputs from overcomplete are tuples, we need to get the codes
-                if isinstance(batch_concepts_activations, tuple):
-                    batch_concepts_activations = batch_concepts_activations[1]  # temporary fix, issue #65
+    if return_counts:
+        return words_count
 
-                concepts_activations_list.append(batch_concepts_activations.cpu())  # type: ignore
-            concepts_activations = torch.cat(concepts_activations_list, dim=0)
-
-            if hasattr(self.concept_model, "to"):
-                self.concept_model.to("cpu")  # type: ignore
-            return concepts_activations
-
-        if inputs is not None:
-            activations_dict: dict[str, LatentActivations] = self.model_with_split_points.get_activations(
-                inputs,
-                activation_granularity=self.activation_granularity,
-            )
-            latent_activations = self.model_with_split_points.get_split_activations(
-                activations_dict, split_point=self.split_point
-            )
-            return self.concepts_activations_from_source(latent_activations=latent_activations, inputs=inputs)
-
-        raise ValueError(
-            "No source provided. Please provide either `inputs`, `latent_activations`, or `concepts_activations`."
-        )
-
-    def concepts_activations_from_vocab(
-        self,
-    ) -> tuple[list[str], Float[torch.Tensor, "nl cpt"]]:
-        """
-        Computes the concepts activations for each token of the vocabulary
-
-        Args:
-            model_with_split_points (ModelWithSplitPoints):
-            split_point (str):
-            concept_model (ConceptModelProtocol):
-
-        Returns:
-            tuple[list[str], Float[torch.Tensor, "nl cpt"]]:
-                - The list of tokens in the vocabulary
-                - The concept activations for each token
-        """
-        # extract and sort the vocabulary
-        vocab_dict: dict[str, int] = self.model_with_split_points.tokenizer.get_vocab()
-        inputs: list[str]
-        input_ids: list[int]
-        inputs, input_ids = zip(*vocab_dict.items(), strict=True)  # type: ignore
-
-        # compute the vocabulary's latent activations
-        if self.activation_granularity == ActivationGranularity.CLS_TOKEN:
-            activations_dict: dict[str, LatentActivations] = self.model_with_split_points.get_activations(  # type: ignore
-                inputs, activation_granularity=ModelWithSplitPoints.activation_granularities.ALL_TOKENS
-            )
-        else:
-            input_tensor: Float[torch.Tensor, "v 1"] = torch.tensor(input_ids).unsqueeze(1)
-            activations_dict: dict[str, LatentActivations] = self.model_with_split_points.get_activations(  # type: ignore
-                input_tensor, activation_granularity=ModelWithSplitPoints.activation_granularities.ALL_TOKENS
-            )
-        latent_activations = self.model_with_split_points.get_split_activations(
-            activations_dict, split_point=self.split_point
-        )
-        concepts_activations = self.concept_model.encode(latent_activations)  # type: ignore
-        if isinstance(concepts_activations, tuple):
-            concepts_activations = concepts_activations[1]  # temporary fix, issue #65
-        return inputs, concepts_activations  # type: ignore
-
-    def get_granular_inputs(
-        self,
-        inputs: list[str],  # (n)
-    ) -> tuple[list[str], list[int]]:  # (ng,)
-        """Split texts from the inputs based on the target granularity
-        (for instance into tokens, words, sentences, ...)
-
-        Args:
-            inputs (list[str]): n text samples
-
-        Returns:
-            tuple[list[str], list[int]]:
-                - list[str]: The granular texts from the inputs, flattened
-                - list[int]: The sample id for each granular text, to keep track of which sample the text belongs to.
-        """
-        if self.activation_granularity is ActivationGranularity.SAMPLE:
-            # no activation_granularity is needed
-            return inputs, list(range(len(inputs)))
-
-        # Get granular texts from the inputs
-        tokens = self.model_with_split_points.tokenizer(
-            inputs, return_tensors="pt", padding=True, return_offsets_mapping=True
-        )
-        granular_texts: list[list[str]] = Granularity.get_decomposition(
-            tokens,
-            granularity=self.activation_granularity.value,  # type: ignore
-            tokenizer=self.model_with_split_points.tokenizer,
-            return_text=True,
-        )  # type: ignore
-
-        granular_flattened_texts = [text for sample_texts in granular_texts for text in sample_texts]
-        granular_flattened_sample_id = [i for i, sample_texts in enumerate(granular_texts) for _ in sample_texts]
-        return granular_flattened_texts, granular_flattened_sample_id
+    return list(words_count.keys())
 
 
 def verify_concepts_indices(
@@ -256,7 +141,7 @@ def verify_concepts_indices(
     if isinstance(concepts_indices, int):
         concepts_indices = [concepts_indices]
 
-    if not isinstance(concepts_indices, list) or not all(isinstance(c, int) for c in concepts_indices):  # type: ignore
+    if not isinstance(concepts_indices, list) or not all(isinstance(c, int) for c in concepts_indices):
         raise ValueError(f"`concepts_indices` should be 'all', an int, or a list of int. Received {concepts_indices}.")
 
     if max(concepts_indices) >= concepts_activations.shape[1] or min(concepts_indices) < 0:
@@ -287,3 +172,326 @@ def verify_granular_inputs(
         raise ValueError(
             f"The lengths of the granulated inputs do not match the number of concepts activations {len(granular_inputs)} != {len(sure_concepts_activations)}"
         )
+
+
+class BaseConceptInterpretationMethod(ABC):
+    """Code: [:octicons-mark-github-24: `concepts/interpretations/base.py` ](https://github.com/FOR-sight-ai/interpreto/blob/dev/interpreto/concepts/interpretations/base.py)
+
+    Abstract class defining an interface for concept interpretation.
+    Its goal is to make the dimensions of the concept space interpretable by humans.
+
+    Attributes:
+    """
+
+    def __init__(
+        self,
+        concept_explainer: ConceptEncoderExplainer,
+        activation_granularity: ActivationGranularity,
+        concept_encoding_batch_size: int = 1024,
+        use_vocab: bool = False,
+        use_unique_words: bool = False,
+        device: torch.device | str | None = "cpu",
+    ):
+        if activation_granularity not in (
+            ActivationGranularity.CLS_TOKEN,
+            ActivationGranularity.TOKEN,
+            ActivationGranularity.WORD,
+            ActivationGranularity.SENTENCE,
+            ActivationGranularity.SAMPLE,
+        ):
+            raise ValueError(
+                f"The granularity {activation_granularity} is not supported. "
+                "Supported `activation_granularities`: CLS_TOKEN, TOKEN, WORD, SENTENCE, and SAMPLE"
+            )
+
+        if use_unique_words and use_vocab:
+            raise ValueError("Cannot use both `use_unique_words` and `use_vocab`. Please use only one of them.")
+
+        if activation_granularity == ActivationGranularity.CLS_TOKEN and not use_unique_words:
+            raise ValueError("Cannot use `activation_granularity` CLS_TOKEN without `use_unique_words` set to True.")
+
+        self.concept_explainer: ConceptEncoderExplainer = concept_explainer
+        self.activation_granularity: ActivationGranularity = activation_granularity
+        self.concept_encoding_batch_size: int = concept_encoding_batch_size
+        self.use_vocab: bool = use_vocab
+        self.use_unique_words: bool = use_unique_words
+        self.device: torch.device | str | None = device
+        self.__call__ = self.interpret
+
+    @abstractmethod
+    def interpret(
+        self,
+        concepts_indices: int | list[int],
+        inputs: list[str] | None = None,
+        latent_activations: dict[str, LatentActivations] | LatentActivations | None = None,
+        concepts_activations: ConceptsActivations | None = None,
+    ) -> Mapping[int, Any]:
+        """
+        Interpret the concepts dimensions in the latent space into a human-readable format.
+        The interpretation is a mapping between the concepts indices and an object allowing to interpret them.
+        It can be a label, a description, examples, etc.
+
+        Args:
+            concepts_indices (int | list[int] | Literal["all"]):
+                The indices of the concepts to interpret. If "all", all concepts are interpreted.
+
+            inputs (list[str] | None):
+                The inputs to use for the interpretation.
+                Necessary if not `use_vocab`,as examples are extracted from the inputs.
+
+            latent_activations (dict[str, torch.Tensor] | Float[torch.Tensor, "nl d"] | None):
+                The latent activations matching the inputs. If not provided,
+                it is computed from the inputs.
+
+            concepts_activations (Float[torch.Tensor, "nl cpt"] | None):
+                The concepts activations matching the inputs. If not provided,
+                it is computed from the inputs or latent activations.
+
+        Returns:
+            Mapping[int, Any]:
+                The interpretation of each of the specified concepts.
+        """
+        raise NotImplementedError
+
+    def concepts_activations_from_source(
+        self,
+        *,
+        inputs: list[str] | None = None,
+        latent_activations: Float[torch.Tensor, "nl d"] | None = None,
+        concepts_activations: Float[torch.Tensor, "nl cpt"] | None = None,
+    ) -> Float[torch.Tensor, "nl cpt"]:
+        """
+        Computes the concepts activations from the given samples.
+        Samples can be provided as raw text (`inputs`), latent activations (`latent_activations`),
+        or directly concept activations (`concepts_activations`).
+
+        Args:
+            inputs (list[str] | None): The indices of the concepts to interpret.
+            latent_activations (Float[torch.Tensor, "nl d"] | None): The latent activations
+            concepts_activations (Float[torch.Tensor, "nl cpt"] | None): The concepts activations
+
+        Returns:
+            Float[torch.Tensor, "nl cpt"] :
+        """
+
+        if concepts_activations is not None:
+            return concepts_activations
+
+        if latent_activations is not None:
+            # batch over latent activations for concept encoding
+            concepts_activations_list = []
+            for batch_idx in range(0, latent_activations.shape[0], self.concept_encoding_batch_size):
+                # extract and encode a batch of latent activations
+                batch_latent_activations = latent_activations[batch_idx : batch_idx + self.concept_encoding_batch_size]
+
+                if hasattr(batch_latent_activations, "to"):
+                    batch_latent_activations = batch_latent_activations.to(self.device)
+                batch_concepts_activations = self.concept_explainer.encode_activations(batch_latent_activations)
+
+                concepts_activations_list.append(batch_concepts_activations.cpu())
+            concepts_activations = torch.cat(concepts_activations_list, dim=0)
+            return concepts_activations
+
+        if inputs is not None:
+            activations_dict: dict[str, LatentActivations] = (
+                self.concept_explainer.model_with_split_points.get_activations(
+                    inputs,
+                    activation_granularity=self.activation_granularity,
+                )
+            )
+            latent_activations = self.concept_explainer.model_with_split_points.get_split_activations(
+                activations_dict, split_point=self.concept_explainer.split_point
+            )
+            return self.concepts_activations_from_source(latent_activations=latent_activations, inputs=inputs)
+
+        raise ValueError(
+            "No source provided. Please provide either `inputs`, `latent_activations`, or `concepts_activations`."
+        )
+
+    @jaxtyped(typechecker=beartype)
+    def concepts_activations_from_vocab(
+        self,
+    ) -> tuple[list[str], Float[torch.Tensor, "nl cpt"]]:
+        """
+        Computes the concepts activations for each token of the vocabulary
+
+        Args:
+            model_with_split_points (ModelWithSplitPoints):
+            split_point (str):
+            concept_model (ConceptModelProtocol):
+
+        Returns:
+            tuple[list[str], Float[torch.Tensor, "nl cpt"]]:
+                - The list of tokens in the vocabulary
+                - The concept activations for each token
+        """
+        # extract and sort the vocabulary
+        vocab_dict: dict[str, int] = self.concept_explainer.model_with_split_points.tokenizer.get_vocab()
+        inputs: tuple[str]
+        input_ids: tuple[int]
+        inputs, input_ids = zip(*vocab_dict.items(), strict=True)
+        inputs: list[str] = list(inputs)
+
+        # compute the vocabulary's latent activations
+        if self.activation_granularity == ActivationGranularity.CLS_TOKEN:
+            activations_dict: dict[str, LatentActivations] = (
+                self.concept_explainer.model_with_split_points.get_activations(
+                    inputs, activation_granularity=ModelWithSplitPoints.activation_granularities.ALL_TOKENS
+                )
+            )
+        else:
+            input_tensor: Float[torch.Tensor, "v 1"] = torch.tensor(input_ids).unsqueeze(1)
+            activations_dict: dict[str, LatentActivations] = (
+                self.concept_explainer.model_with_split_points.get_activations(
+                    input_tensor, activation_granularity=ModelWithSplitPoints.activation_granularities.ALL_TOKENS
+                )
+            )
+        latent_activations = self.concept_explainer.model_with_split_points.get_split_activations(
+            activations_dict, split_point=self.concept_explainer.split_point
+        )
+        concepts_activations = self.concept_explainer.encode_activations(latent_activations)
+        return inputs, concepts_activations
+
+    @jaxtyped(typechecker=beartype)
+    def get_granular_inputs(
+        self,
+        inputs: list[str],  # (n)
+    ) -> tuple[list[str], list[int]]:  # (ng,)
+        """Split texts from the inputs based on the target granularity
+        (for instance into tokens, words, sentences, ...)
+
+        Args:
+            inputs (list[str]): n text samples
+
+        Returns:
+            tuple[list[str], list[int]]:
+                - list[str]: The granular texts from the inputs, flattened
+                - list[int]: The sample id for each granular text, to keep track of which sample the text belongs to.
+        """
+        if self.activation_granularity is ActivationGranularity.SAMPLE:
+            # no activation_granularity is needed
+            return inputs, list(range(len(inputs)))
+
+        # Get granular texts from the inputs
+        tokens = self.concept_explainer.model_with_split_points.tokenizer(
+            inputs, return_tensors="pt", padding=True, return_offsets_mapping=True
+        )
+        granular_texts: list[list[str]] = Granularity.get_decomposition(  # type: ignore  (sure list[list[str]] with return_text=True)
+            tokens,
+            granularity=self.activation_granularity.value,  # type: ignore
+            tokenizer=self.concept_explainer.model_with_split_points.tokenizer,
+            return_text=True,
+        )
+
+        granular_flattened_texts = [text for sample_texts in granular_texts for text in sample_texts]
+        granular_flattened_sample_id = [i for i, sample_texts in enumerate(granular_texts) for _ in sample_texts]
+        return granular_flattened_texts, granular_flattened_sample_id
+
+    def get_granular_inputs_and_concept_activations(
+        self,
+        concepts_indices: int | list[int] | Literal["all"],
+        inputs: list[str] | None = None,
+        latent_activations: dict[str, LatentActivations] | LatentActivations | None = None,
+        concepts_activations: ConceptsActivations | None = None,
+    ) -> tuple[list[int], list[str], Float[torch.Tensor, "nl cpt"], list[int]]:
+        """
+        Compute the granular inputs and concept activations for the specified concepts.
+
+        Args:
+            concepts_indices (int | list[int] | Literal["all"]):
+                The indices of the concepts to interpret. If "all", all concepts are interpreted.
+
+            inputs (list[str] | None):
+                The inputs to use for the interpretation.
+                Necessary if not `use_vocab`,as examples are extracted from the inputs.
+
+            latent_activations (dict[str, torch.Tensor] | Float[torch.Tensor, "nl d"] | None):
+                The latent activations matching the inputs. If not provided,
+                it is computed from the inputs.
+
+            concepts_activations (Float[torch.Tensor, "nl cpt"] | None):
+                The concepts activations matching the inputs. If not provided,
+                it is computed from the inputs or latent activations.
+
+        Returns:
+            sure_concepts_indices (list[int]):
+                The indices of the concepts to interpret.
+
+            granular_inputs (list[str]):
+                The granular inputs for the specified concepts.
+                Each element of the list is a single granular input, such as a word.
+
+            sure_concepts_activations (Float[torch.Tensor, "nl cpt"]):
+                The concepts activations matching the granular inputs.
+
+            granular_sample_ids (list[int]):
+                The granular sample ids for the specified concepts.
+
+        """
+        if concepts_indices == "all":
+            concepts_indices = list(range(self.concept_explainer.concept_model.nb_concepts))
+
+        # verify
+        if latent_activations is not None:
+            latent_activations = self.concept_explainer._sanitize_activations(latent_activations)
+        else:
+            latent_activations = None
+
+        # compute the concepts activations from the provided source, can also create inputs from the vocabulary
+        if self.use_vocab:
+            # --------------------------------------------------------------------------------------
+            # Case 1: use_vocab=True
+            granular_inputs: list[str]
+            sure_concepts_activations: Float[torch.Tensor, "nl cpt"]
+            granular_inputs, sure_concepts_activations = self.concepts_activations_from_vocab()
+
+            granular_sample_ids: list[int] = list(range(len(granular_inputs)))
+        else:
+            if inputs is None:
+                raise ValueError("Inputs must be provided when `use_vocab` is False.")
+
+            if self.use_unique_words:
+                # ----------------------------------------------------------------------------------
+                # Case 2: use_unique_words=True
+                # first list unique words from the inputs and compute the activations from them
+                granular_inputs: list[str] = extract_unique_words(inputs=inputs, return_counts=False)  # type: ignore  (sure list[str] with return_counts=False)
+                if latent_activations is not None and concepts_activations is not None:
+                    warnings.warn(
+                        "`latent_activations` or `concepts_activations` were provided, "
+                        "but `use_unique_words` is True. "
+                        "Therefore, the inputs and activations will likely mismatch. "
+                        "Either do not provide `latent_activations` and `concepts_activations`, "
+                        "or use `interpreto.concepts.interpretation.extract_unique_words` yourself, "
+                        "and set `use_unique_words` to False.",
+                        stacklevel=2,
+                    )
+                sure_concepts_activations = self.concepts_activations_from_source(
+                    inputs=granular_inputs,
+                    latent_activations=latent_activations,
+                    concepts_activations=concepts_activations,
+                )
+
+                granular_sample_ids: list[int] = list(range(len(granular_inputs)))
+            else:
+                # ----------------------------------------------------------------------------------
+                # Case 3: Default, use_vocab=False and use_unique_words=False
+                sure_concepts_activations = self.concepts_activations_from_source(
+                    inputs=inputs,
+                    latent_activations=latent_activations,
+                    concepts_activations=concepts_activations,
+                )
+                granular_inputs: list[str]
+                granular_sample_ids: list[int]
+                granular_inputs, granular_sample_ids = self.get_granular_inputs(inputs)
+
+        sure_concepts_indices = verify_concepts_indices(
+            concepts_activations=sure_concepts_activations, concepts_indices=concepts_indices
+        )
+        verify_granular_inputs(
+            granular_inputs=granular_inputs,
+            sure_concepts_activations=sure_concepts_activations,
+            latent_activations=latent_activations,
+            concepts_activations=concepts_activations,
+        )
+
+        return (sure_concepts_indices, granular_inputs, sure_concepts_activations, granular_sample_ids)

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -327,9 +327,7 @@ class BaseConceptInterpretationMethod(ABC):
         """
         # extract and sort the vocabulary
         vocab_dict: dict[str, int] = self.concept_explainer.model_with_split_points.tokenizer.get_vocab()
-        inputs: tuple[str]
-        input_ids: tuple[int]
-        inputs, input_ids = zip(*vocab_dict.items(), strict=True)
+        inputs, input_ids = zip(*vocab_dict.items(), strict=True)  # type: ignore
         inputs: list[str] = list(inputs)
 
         # compute the vocabulary's latent activations

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -101,9 +101,9 @@ def extract_unique_words(
         ValueError:
             If the input is not a list of strings.
     """
-    nltk.download("wordnet")
-    nltk.download("punkt")
-    nltk.download("punkt_tab")
+    nltk.download("wordnet", quiet=True)
+    nltk.download("punkt", quiet=True)
+    nltk.download("punkt_tab", quiet=True)
     if lemmatize:
         lemmatizer = WordNetLemmatizer()
 

--- a/interpreto/concepts/interpretations/llm_labels.py
+++ b/interpreto/concepts/interpretations/llm_labels.py
@@ -138,6 +138,10 @@ class LLMLabels(BaseConceptInterpretationMethod):
             please use the `extract_unique_words` function directly,
             and pass the result to the `LLMLabels` class.
 
+        unique_words_kwargs (dict):
+            The kwargs to pass to the `extract_unique_words` function.
+            see `interpreto.concepts.interpretations.topk_inputs.extract_unique_words` for more details.
+
         k_quantile (int):
             The number of quantiles to use for sampling the inputs, if `sampling_method` is `QUANTILE`.
 
@@ -156,6 +160,7 @@ class LLMLabels(BaseConceptInterpretationMethod):
         k_context: int = 0,
         use_vocab: bool = False,
         use_unique_words: bool = False,
+        unique_words_kwargs: dict = {},
         k_quantile: int = 5,
         system_prompt: str | None = None,
         device: torch.device | str | None = "cpu",
@@ -165,6 +170,7 @@ class LLMLabels(BaseConceptInterpretationMethod):
             activation_granularity=activation_granularity,
             use_vocab=use_vocab,
             use_unique_words=use_unique_words,
+            unique_words_kwargs=unique_words_kwargs,
             device=device,
         )
 

--- a/interpreto/concepts/interpretations/llm_labels.py
+++ b/interpreto/concepts/interpretations/llm_labels.py
@@ -28,20 +28,18 @@ from __future__ import annotations
 import warnings
 from collections.abc import Mapping
 from enum import Enum
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import torch
 from jaxtyping import Float
 
-from interpreto import ModelWithSplitPoints
+from interpreto.concepts.base import ConceptEncoderExplainer
 from interpreto.concepts.interpretations.base import (
     BaseConceptInterpretationMethod,
-    verify_concepts_indices,
-    verify_granular_inputs,
 )
 from interpreto.model_wrapping.llm_interface import LLMInterface, Role
 from interpreto.model_wrapping.model_with_split_points import ActivationGranularity
-from interpreto.typing import ConceptModelProtocol, ConceptsActivations, LatentActivations
+from interpreto.typing import ConceptsActivations, LatentActivations
 
 
 class SamplingMethod(Enum):
@@ -108,58 +106,72 @@ class LLMLabels(BaseConceptInterpretationMethod):
         2023.
 
     Attributes:
-        model_with_split_points (ModelWithSplitPoints): The model with split points to use for the interpretation.
-        split_point (str): The split point to use for the interpretation.
-        concept_model (ConceptModelProtocol): The concept model to use for the interpretation.
-        activation_granularity (ActivationGranularity): The granularity at which the interpretation is computed.
-            Allowed values are `TOKEN`, `WORD`, `SENTENCE`, and `SAMPLE`.
+        concept_explainer (ConceptEncoderExplainer):
+            The fitted concept explainer used for encoding activations.
+
+        activation_granularity (ActivationGranularity):
+            The granularity at which the interpretation is computed.
+            Allowed values are `CLS_TOKEN`, `TOKEN`, `WORD`, `SENTENCE`, and `SAMPLE`.
             Ignored when use_vocab=True.
-        llm_interface (LLMInterface): The LLM interface to use for the interpretation.
-        sampling_method (SAMPLING_METHOD): The method to use for sampling the inputs provided to the LLM.
-        k_examples (int): The number of inputs to use for the interpretation.
-        k_context (int): The number of context tokens to use around the concept tokens.
-        use_vocab (bool): If True, the interpretation will be computed from the vocabulary of the model.
-        k_quantile (int): The number of quantiles to use for sampling the inputs, if `sampling_method` is `QUANTILE`.
-        system_prompt (str | None): The system prompt to use for the LLM. If None, a default prompt is used.
+
+        llm_interface (LLMInterface):
+            The LLM interface to use for the interpretation.
+
+        sampling_method (SAMPLING_METHOD):
+            The method to use for sampling the inputs provided to the LLM.
+
+        k_examples (int):
+            The number of inputs to use for the interpretation.
+
+        k_context (int):
+            The number of context tokens to use around the concept tokens.
+
+        use_vocab (bool):
+            If True, the interpretation will be computed from the vocabulary of the model.
+
+        use_unique_words (bool):
+            If True, the interpretation will be computed from the unique words of the model.
+            Required when activation_granularity is `CLS_TOKEN`.
+            Incompatible with `use_vocab=True`.
+            This is built upon the `extract_unique_words` function.
+            For more advanced selection of unique words,
+            please use the `extract_unique_words` function directly,
+            and pass the result to the `LLMLabels` class.
+
+        k_quantile (int):
+            The number of quantiles to use for sampling the inputs, if `sampling_method` is `QUANTILE`.
+
+        system_prompt (str | None):
+            The system prompt to use for the LLM. If None, a default prompt is used.
     """
 
     def __init__(
         self,
         *,
-        model_with_split_points: ModelWithSplitPoints,
-        concept_model: ConceptModelProtocol,
-        split_point: str | None = None,
+        concept_explainer: ConceptEncoderExplainer,
         activation_granularity: ActivationGranularity = ActivationGranularity.TOKEN,
         llm_interface: LLMInterface,
         sampling_method: SamplingMethod = SamplingMethod.TOP,
         k_examples: int = 30,
         k_context: int = 0,
         use_vocab: bool = False,
+        use_unique_words: bool = False,
         k_quantile: int = 5,
         system_prompt: str | None = None,
+        device: torch.device | str | None = "cpu",
     ):
         super().__init__(
-            model_with_split_points=model_with_split_points,
-            split_point=split_point,
-            concept_model=concept_model,
+            concept_explainer=concept_explainer,
             activation_granularity=activation_granularity,
+            use_vocab=use_vocab,
+            use_unique_words=use_unique_words,
+            device=device,
         )
-
-        if activation_granularity not in (
-            ActivationGranularity.TOKEN,
-            ActivationGranularity.WORD,
-            ActivationGranularity.SENTENCE,
-            ActivationGranularity.SAMPLE,
-        ):
-            raise ValueError(
-                f"The granularity {activation_granularity} is not supported. Supported `activation_granularities`: TOKEN, WORD, SENTENCE, and SAMPLE"
-            )
 
         self.llm_interface = llm_interface
         self.sampling_method = sampling_method
         self.k_examples = k_examples
         self.k_context = k_context
-        self.use_vocab = use_vocab
         self.k_quantile = k_quantile
 
         if system_prompt is None:
@@ -172,9 +184,9 @@ class LLMLabels(BaseConceptInterpretationMethod):
 
     def interpret(
         self,
-        concepts_indices: int | list[int],
+        concepts_indices: int | list[int] | Literal["all"],
         inputs: list[str] | None = None,
-        latent_activations: LatentActivations | None = None,
+        latent_activations: dict[str, torch.Tensor] | LatentActivations | None = None,
         concepts_activations: ConceptsActivations | None = None,
     ) -> Mapping[int, str | None]:
         """
@@ -182,44 +194,41 @@ class LLMLabels(BaseConceptInterpretationMethod):
         The interpretation is a mapping between the concepts indices and a short textual description.
         The granularity of input examples is determined by the `activation_granularity` class attribute.
 
+
         Args:
-            concepts_indices (int | list[int]): The indices of the concepts to interpret.
-            inputs (list[str] | None): The inputs to use for the interpretation.
-                Necessary if not `use_vocab`, as examples are extracted from the inputs.
-            latent_activations (Float[torch.Tensor, "nl d"] | None): The latent activations matching the inputs. If not provided, it is computed from the inputs.
-            concepts_activations (Float[torch.Tensor, "nl cpt"] | None): The concepts activations matching the inputs. If not provided, it is computed from the inputs or latent activations.
+            concepts_indices (int | list[int] | Literal["all"]):
+                The indices of the concepts to interpret. If "all", all concepts are interpreted.
+
+            inputs (list[str] | None):
+                The inputs to use for the interpretation.
+                Necessary if not `use_vocab`,as examples are extracted from the inputs.
+
+            latent_activations (dict[str, torch.Tensor] | Float[torch.Tensor, "nl d"] | None):
+                The latent activations matching the inputs. If not provided,
+                it is computed from the inputs.
+
+            concepts_activations (Float[torch.Tensor, "nl cpt"] | None):
+                The concepts activations matching the inputs. If not provided,
+                it is computed from the inputs or latent activations.
+
         Returns:
             Mapping[int, str | None]: The textual labels of the concepts indices.
         """
-
-        if self.use_vocab:
-            sure_inputs, sure_concepts_activations = self.concepts_activations_from_vocab()
-            granular_inputs = sure_inputs
-            granular_sample_ids = list(range(len(sure_inputs)))
-        else:
-            if inputs is None:
-                raise ValueError("Inputs must be provided when `use_vocab` is False.")
-            sure_inputs = inputs
-            sure_concepts_activations = self.concepts_activations_from_source(
+        sure_concepts_indices: list[int]
+        granular_inputs: list[str]
+        sure_concepts_activations: Float[torch.Tensor, "nl cpt"]
+        granular_sample_ids: list[int]
+        sure_concepts_indices, granular_inputs, sure_concepts_activations, granular_sample_ids = (
+            self.get_granular_inputs_and_concept_activations(
+                concepts_indices=concepts_indices,
                 inputs=inputs,
                 latent_activations=latent_activations,
                 concepts_activations=concepts_activations,
             )
-            granular_inputs, granular_sample_ids = self.get_granular_inputs(sure_inputs)
-
-        concepts_indices = verify_concepts_indices(
-            concepts_activations=sure_concepts_activations,
-            concepts_indices=concepts_indices,
-        )
-        verify_granular_inputs(
-            granular_inputs=granular_inputs,
-            sure_concepts_activations=sure_concepts_activations,
-            latent_activations=latent_activations,
-            concepts_activations=concepts_activations,
         )
 
         labels: Mapping[int, str | None] = {}
-        for concept_idx in concepts_indices:
+        for concept_idx in sure_concepts_indices:
             example_idx = self.sampling_method.sample_examples(
                 concept_activations=sure_concepts_activations[:, concept_idx],
                 k_examples=self.k_examples,

--- a/interpreto/concepts/interpretations/llm_labels.py
+++ b/interpreto/concepts/interpretations/llm_labels.py
@@ -130,17 +130,15 @@ class LLMLabels(BaseConceptInterpretationMethod):
             If True, the interpretation will be computed from the vocabulary of the model.
 
         use_unique_words (bool):
-            If True, the interpretation will be computed from the unique words of the model.
-            Required when activation_granularity is `CLS_TOKEN`.
+            If True, the interpretation will be computed from the unique words of the inputs.
             Incompatible with `use_vocab=True`.
-            This is built upon the `extract_unique_words` function.
-            For more advanced selection of unique words,
-            please use the `extract_unique_words` function directly,
-            and pass the result to the `LLMLabels` class.
+            Default unique words selects all different word from the input.
+            It can be tuned through the `unique_words_kwargs` argument.
 
         unique_words_kwargs (dict):
             The kwargs to pass to the `extract_unique_words` function.
             see `interpreto.concepts.interpretations.topk_inputs.extract_unique_words` for more details.
+            Possible arguments are `count_min_threshold`, `lemmatize`, `words_to_ignore`.
 
         k_quantile (int):
             The number of quantiles to use for sampling the inputs, if `sampling_method` is `QUANTILE`.

--- a/interpreto/concepts/interpretations/topk_inputs.py
+++ b/interpreto/concepts/interpretations/topk_inputs.py
@@ -83,6 +83,10 @@ class TopKInputs(BaseConceptInterpretationMethod):
             please use the `extract_unique_words` function directly,
             and pass the result to the `TopKInputs` class.
 
+        unique_words_kwargs (dict):
+            The kwargs to pass to the `extract_unique_words` function.
+            see `interpreto.concepts.interpretations.topk_inputs.extract_unique_words` for more details.
+
         device (torch.device | str | None):
             The device to use for forward passes.
             If None, use the one from `model_with_split_points`.
@@ -126,6 +130,7 @@ class TopKInputs(BaseConceptInterpretationMethod):
         k: int = 5,
         use_vocab: bool = False,
         use_unique_words: bool = False,
+        unique_words_kwargs: dict = {},
         device: torch.device | str | None = "cpu",
     ):
         super().__init__(
@@ -134,6 +139,7 @@ class TopKInputs(BaseConceptInterpretationMethod):
             concept_encoding_batch_size=concept_encoding_batch_size,
             use_vocab=use_vocab,
             use_unique_words=use_unique_words,
+            unique_words_kwargs=unique_words_kwargs,
             device=device,
         )
 

--- a/interpreto/concepts/interpretations/topk_inputs.py
+++ b/interpreto/concepts/interpretations/topk_inputs.py
@@ -28,109 +28,18 @@ Base class for concept interpretation methods.
 
 from __future__ import annotations
 
-import warnings
 from collections import Counter
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
-import nltk
 import torch
-from nltk.stem import WordNetLemmatizer
-from nltk.tokenize import word_tokenize
 
-from interpreto import ModelWithSplitPoints
+from interpreto.concepts.base import ConceptEncoderExplainer
 from interpreto.concepts.interpretations.base import (
     BaseConceptInterpretationMethod,
-    verify_concepts_indices,
-    verify_granular_inputs,
 )
 from interpreto.model_wrapping.model_with_split_points import ActivationGranularity
-from interpreto.typing import ConceptModelProtocol, ConceptsActivations, LatentActivations
-
-
-def extract_unique_words(
-    inputs: list[str],
-    count_min_threshold: int = 1,
-    return_counts: bool = False,
-    lemmatize: bool = False,
-    words_to_ignore: list[str] | None = None,
-) -> list[str] | Counter[str]:
-    """
-    Extract words from a text.
-
-    Depending on parameters, it may select a subset of words or return the counts of each word.
-
-    Args:
-        inputs (str):
-            The text to extract words from.
-
-        count_min_threshold (float, optional):
-            The minimum total number of a occurrence of a word in the whole `inputs`.
-
-        return_counts (bool, optional):
-            Whether to return the counts of each word.
-            Defaults to False.
-
-        words_to_ignore: (list[str], optional):
-            A list of words to ignore.
-
-    Examples:
-        Fastest version as used in `TopKInputs`.
-        >>> extract_unique_words(["Interpreto is the latin for 'to interpret'.", "interpreto is magic"])
-        ["interpreto", "is", "the", "latin", "for", "to", "'", "interpret", ".", "magic"]
-
-        More complex use:
-        >>> from datasets import load_dataset
-        >>> from nltk.corpus import stopwords
-        >>> from interpreto.concepts.interpretations.topk_inputs import extract_unique_words
-        >>> dataset = load_dataset("cornell-movie-review-data/rotten_tomatoes")["train"]["text"]
-        >>> extract_unique_words(
-        ...     inputs=dataset,
-        ...     count_min_threshold=20,
-        ...     return_counts=True,
-        ...     lemmatize=True,
-        ...     words_to_ignore=stopwords.words("english"),
-        ... )
-        Counter(TODO)
-
-    Returns:
-        list[str] | Counter[str]:
-            The list of unique words or the counts of each word.
-
-    Raises:
-        ValueError:
-            If the input is not a list of strings.
-    """
-    nltk.download("wordnet")
-    nltk.download("punkt")
-    nltk.download("punkt_tab")
-    if lemmatize:
-        lemmatizer = WordNetLemmatizer()
-
-    # counter both list unique words and counts of each word
-    words_count = Counter()
-
-    for text in inputs:
-        for word in word_tokenize(text):
-            # lemmatize words
-            if lemmatize:
-                word = lemmatizer.lemmatize(word.lower())  # type: ignore  # noqa: PLW2901
-
-            # ignore words
-            if words_to_ignore is not None and word in words_to_ignore:
-                continue
-
-            # add word to counter
-            words_count[word] += 1
-
-    # filter too rare words
-    if count_min_threshold > 1:
-        words_count = Counter({key: count for key, count in words_count.items() if count >= count_min_threshold})
-
-    if return_counts:
-        return words_count
-
-    return list(words_count.keys())
+from interpreto.typing import ConceptsActivations, LatentActivations
 
 
 class TopKInputs(BaseConceptInterpretationMethod):
@@ -148,19 +57,13 @@ class TopKInputs(BaseConceptInterpretationMethod):
         Transformer Circuits, 2023.
 
     Arguments:
-        model_with_split_points (ModelWithSplitPoints):
-            The model with split points to use for the interpretation.
-
-        concept_model (ConceptModelProtocol):
-            The concept model to use for the interpretation.
+        concept_explainer (ConceptEncoderExplainer):
+            The concept explainer built on top of a `ModelWithSplitPoints`.
 
         activation_granularity (ActivationGranularity):
             The granularity at which the interpretation is computed.
             Allowed values are `CLS_TOKEN`, `TOKEN`, `WORD`, `SENTENCE`, and `SAMPLE`.
             Ignored when `use_vocab=True`.
-
-        split_point (str):
-            The split point to use for the interpretation.
 
         concept_encoding_batch_size (int):
             The batch size to use for the concept encoding.
@@ -187,9 +90,6 @@ class TopKInputs(BaseConceptInterpretationMethod):
     TODO:
         Adapt example to added arguments, one example for generation, one for classification
 
-        Change API from concept_explainer.interpret(TopKInputs, ...) to
-            topk_inputs = TopKInputs(concept_explainer) and topk_inputs.interpret(...)
-
     Examples:
         >>> from datasets import load_dataset
         >>> from interpreto import ModelWithSplitPoints
@@ -204,13 +104,11 @@ class TopKInputs(BaseConceptInterpretationMethod):
         ...     batch_size=4,
         ... )
         >>> # NeuronsAsConcepts do not need to be fitted
-        >>> concept_model = NeuronsAsConcepts(model_with_split_points=model_with_split_points, split_point=split)
+        >>> concept_explainer = NeuronsAsConcepts(model_with_split_points=model_with_split_points, split_point=split)
         >>> # extracting concept interpretations
         >>> dataset = load_dataset("cornell-movie-review-data/rotten_tomatoes")["train"]["text"]
-        >>> all_top_k_words = concept_model.interpret(
-        ...     interpretation_method=TopKInputs,
-        ...     activation_granularity=TopKInputs.activation_granularities.WORD,
-        ...     k=2,
+        >>> interpretation_method = TopKInputs(concept_explainer)
+        >>> all_top_k_words = interpretation_method.interpret(
         ...     concepts_indices="all",
         ...     inputs=dataset,
         ...     latent_activations=activations,
@@ -222,52 +120,30 @@ class TopKInputs(BaseConceptInterpretationMethod):
     def __init__(
         self,
         *,
-        model_with_split_points: ModelWithSplitPoints,
-        concept_model: ConceptModelProtocol,
+        concept_explainer: ConceptEncoderExplainer,
         activation_granularity: ActivationGranularity = ActivationGranularity.WORD,
-        split_point: str | None = None,
         concept_encoding_batch_size: int = 1024,
         k: int = 5,
         use_vocab: bool = False,
         use_unique_words: bool = False,
         device: torch.device | str | None = "cpu",
     ):
-        if activation_granularity not in (
-            ActivationGranularity.CLS_TOKEN,
-            ActivationGranularity.TOKEN,
-            ActivationGranularity.WORD,
-            ActivationGranularity.SENTENCE,
-            ActivationGranularity.SAMPLE,
-        ):
-            raise ValueError(
-                f"The granularity {activation_granularity} is not supported. "
-                "Supported `activation_granularities`: CLS_TOKEN, TOKEN, WORD, SENTENCE, and SAMPLE"
-            )
-
-        if use_unique_words and use_vocab:
-            raise ValueError("Cannot use both `use_unique_words` and `use_vocab`. Please use only one of them.")
-
-        if activation_granularity == ActivationGranularity.CLS_TOKEN and not use_unique_words:
-            raise ValueError("Cannot use `activation_granularity` CLS_TOKEN without `use_unique_words` set to True.")
-
         super().__init__(
-            model_with_split_points=model_with_split_points,
-            concept_model=concept_model,
-            split_point=split_point,
+            concept_explainer=concept_explainer,
             activation_granularity=activation_granularity,
             concept_encoding_batch_size=concept_encoding_batch_size,
+            use_vocab=use_vocab,
+            use_unique_words=use_unique_words,
             device=device,
         )
 
         self.k = k
-        self.use_vocab = use_vocab
-        self.use_unique_words = use_unique_words
 
     def interpret(
         self,
-        concepts_indices: int | list[int],
+        concepts_indices: int | list[int] | Literal["all"],
         inputs: list[str] | None = None,
-        latent_activations: LatentActivations | None = None,
+        latent_activations: dict[str, torch.Tensor] | LatentActivations | None = None,
         concepts_activations: ConceptsActivations | None = None,
     ) -> Mapping[int, Any]:
         """
@@ -280,65 +156,41 @@ class TopKInputs(BaseConceptInterpretationMethod):
         If all activations are zero, the corresponding concept interpretation is set to `None`.
 
         Args:
-            concepts_indices (int | list[int]): The indices of the concepts to interpret.
-            inputs (list[str] | None): The inputs to use for the interpretation.
-                Necessary if not `use_vocab`, as examples are extracted from the inputs.
-            latent_activations (Float[torch.Tensor, "nl d"] | None): The latent activations matching the inputs. If not provided, it is computed from the inputs.
-            concepts_activations (Float[torch.Tensor, "nl cpt"] | None): The concepts activations matching the inputs. If not provided, it is computed from the inputs or latent activations.
+            concepts_indices (int | list[int] | Literal["all"]):
+                The indices of the concepts to interpret. If "all", all concepts are interpreted.
+
+            inputs (list[str] | None):
+                The inputs to use for the interpretation.
+                Necessary if not `use_vocab`,as examples are extracted from the inputs.
+
+            latent_activations (dict[str, torch.Tensor] | Float[torch.Tensor, "nl d"] | None):
+                The latent activations matching the inputs. If not provided,
+                it is computed from the inputs.
+
+            concepts_activations (Float[torch.Tensor, "nl cpt"] | None):
+                The concepts activations matching the inputs. If not provided,
+                it is computed from the inputs or latent activations.
 
         Returns:
             Mapping[int, Any]: The interpretation of the concepts indices.
 
         """
-        # compute the concepts activations from the provided source, can also create inputs from the vocabulary
-        if self.use_vocab:
-            granular_inputs, sure_concepts_activations = self.concepts_activations_from_vocab()
-        else:
-            if inputs is None:
-                raise ValueError("Inputs must be provided when `use_vocab` is False.")
-
-            if self.use_unique_words:
-                # first list unique words from the inputs and compute the activations from them
-                granular_inputs: list[str] = extract_unique_words(inputs=inputs, return_counts=False)  # type: ignore
-                if latent_activations is not None and concepts_activations is not None:
-                    warnings.warn(
-                        "`latent_activations` or `concepts_activations` were provided, "
-                        "but `use_unique_words` is True. "
-                        "Therefore, the inputs and activations will likely mismatch. "
-                        "Either do not provide `latent_activations` and `concepts_activations`, "
-                        "or use `interpreto.concepts.interpretation.topk_inputs.extract_unique_words` yourself, "
-                        "and set `use_unique_words` to False.",
-                        stacklevel=2,
-                    )
-                sure_concepts_activations = self.concepts_activations_from_source(
-                    inputs=granular_inputs,
-                    latent_activations=latent_activations,
-                    concepts_activations=concepts_activations,
-                )
-            else:
-                # default case
-                sure_inputs = inputs
-                sure_concepts_activations = self.concepts_activations_from_source(
-                    inputs=sure_inputs,
-                    latent_activations=latent_activations,
-                    concepts_activations=concepts_activations,
-                )
-                granular_inputs, _ = self.get_granular_inputs(inputs)
-
-        concepts_indices = verify_concepts_indices(
-            concepts_activations=sure_concepts_activations, concepts_indices=concepts_indices
+        sure_concepts_indices, granular_inputs, sure_concepts_activations, _ = (
+            self.get_granular_inputs_and_concept_activations(
+                concepts_indices=concepts_indices,
+                inputs=inputs,
+                latent_activations=latent_activations,
+                concepts_activations=concepts_activations,
+            )
         )
-        verify_granular_inputs(
-            granular_inputs=granular_inputs,
-            sure_concepts_activations=sure_concepts_activations,
-            latent_activations=latent_activations,
-            concepts_activations=concepts_activations,
-        )
+        sure_concepts_indices: list[int]
+        granular_inputs: list[str]
+        sure_concepts_activations: torch.Tensor
 
         return self._topk_inputs_from_concepts_activations(
             inputs=granular_inputs,
             concepts_activations=sure_concepts_activations,
-            concepts_indices=concepts_indices,
+            concepts_indices=sure_concepts_indices,
         )
 
     def _topk_inputs_from_concepts_activations(

--- a/interpreto/concepts/interpretations/topk_inputs.py
+++ b/interpreto/concepts/interpretations/topk_inputs.py
@@ -75,17 +75,15 @@ class TopKInputs(BaseConceptInterpretationMethod):
             If True, the interpretation will be computed from the vocabulary of the model.
 
         use_unique_words (bool):
-            If True, the interpretation will be computed from the unique words of the model.
-            Required when activation_granularity is `CLS_TOKEN`.
+            If True, the interpretation will be computed from the unique words of the inputs.
             Incompatible with `use_vocab=True`.
-            This is built upon the `extract_unique_words` function.
-            For more advanced selection of unique words,
-            please use the `extract_unique_words` function directly,
-            and pass the result to the `TopKInputs` class.
+            Default unique words selects all different word from the input.
+            It can be tuned through the `unique_words_kwargs` argument.
 
         unique_words_kwargs (dict):
             The kwargs to pass to the `extract_unique_words` function.
             see `interpreto.concepts.interpretations.topk_inputs.extract_unique_words` for more details.
+            Possible arguments are `count_min_threshold`, `lemmatize`, `words_to_ignore`.
 
         device (torch.device | str | None):
             The device to use for forward passes.

--- a/interpreto/concepts/metrics/consim.py
+++ b/interpreto/concepts/metrics/consim.py
@@ -773,7 +773,7 @@ class ConSim:
                 raise ValueError(
                     "Concepts interpretation must be provided if prompt_type is not a baseline."
                     "`concepts_interpretation` is an argument of the `ConSim.evaluate()` method, but it is None."
-                    "It can be computed via `concept_explainer.interpret`."
+                    "It can be computed via `TopKInputs(concept_explainer).interpret`."
                 )
 
             # for each concept, show 10 words, 5 that aligns the most and 5 that are the most opposed
@@ -970,7 +970,7 @@ class ConSim:
             raise ValueError(
                 "Concepts interpretation must be provided if prompt_type is not a baseline."
                 "`concepts_interpretation` is an argument of the `ConSim.evaluate()` method, but it is None."
-                "It can be computed via `concept_explainer.interpret`."
+                "It can be computed via `TopKInputs(concept_explainer).interpret`."
             )
 
         if prompt_type.value.concepts_global_importances and global_importances is None:

--- a/tests/concepts/interpretation/test_llm_labels.py
+++ b/tests/concepts/interpretation/test_llm_labels.py
@@ -304,11 +304,9 @@ def test_llm_labels_concept_selection(splitted_encoder: ModelWithSplitPoints):
     """
     hidden_size = 32
     split = "bert.encoder.layer.1.output"
-    concept_model = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split).concept_model
+    concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split)
     interpretation_method = LLMLabels(
-        model_with_split_points=splitted_encoder,
-        split_point=split,
-        concept_model=concept_model,
+        concept_explainer=concept_explainer,
         activation_granularity=ActivationGranularity.TOKEN,
         llm_interface=LLMInterfaceMock(),
         sampling_method=SamplingMethod.TOP,
@@ -347,13 +345,13 @@ def test_llm_labels_concept_selection(splitted_encoder: ModelWithSplitPoints):
         ModelWithSplitPoints.activation_granularities.SAMPLE,
     ],
 )
-def test_llm_labels_granularity(splitted_encoder: ModelWithSplitPoints, activation_granularity: ActivationGranularity):
+def test_llm_labels_granularity(
+    splitted_encoder: ModelWithSplitPoints, activation_granularity: ActivationGranularity
+):
     split = "bert.encoder.layer.1.output"
-    concept_model = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split).concept_model
+    concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split)
     interpretation_method = LLMLabels(
-        model_with_split_points=splitted_encoder,
-        split_point=split,
-        concept_model=concept_model,
+        concept_explainer=concept_explainer,
         activation_granularity=activation_granularity,
         llm_interface=LLMInterfaceMock(),
         sampling_method=SamplingMethod.TOP,
@@ -397,9 +395,7 @@ def test_llm_labels_sources(splitted_encoder: ModelWithSplitPoints):
     concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split)
 
     interpretation_method = LLMLabels(
-        model_with_split_points=splitted_encoder,
-        split_point=split,
-        concept_model=concept_explainer.concept_model,
+        concept_explainer=concept_explainer,
         activation_granularity=ActivationGranularity.TOKEN,
         llm_interface=LLMInterfaceMock(),
         sampling_method=SamplingMethod.TOP,
@@ -459,9 +455,7 @@ def test_llm_labels_from_vocabulary(splitted_encoder: ModelWithSplitPoints):
     concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split)
 
     interpretation_method = LLMLabels(
-        model_with_split_points=splitted_encoder,
-        split_point=split,
-        concept_model=concept_explainer.concept_model,
+        concept_explainer=concept_explainer,
         activation_granularity=ActivationGranularity.TOKEN,
         llm_interface=LLMInterfaceMock(),
         sampling_method=SamplingMethod.TOP,
@@ -484,15 +478,16 @@ def test_llm_labels_call_from_concept_module(splitted_encoder: ModelWithSplitPoi
     split = "bert.encoder.layer.1.output"
     concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split)
 
-    label = concept_explainer.interpret(
-        interpretation_method=LLMLabels,
+    label = LLMLabels(
+        concept_explainer=concept_explainer,
         activation_granularity=ActivationGranularity.TOKEN,
-        concepts_indices=torch.randperm(hidden_size)[:nb_concepts].tolist(),
         use_vocab=False,
-        inputs=["This is a sentence", "This is another sentence"],
         sampling_method=SamplingMethod.TOP,
         k_context=0,
         llm_interface=LLMInterfaceMock(),
+    ).interpret(
+        concepts_indices=torch.randperm(hidden_size)[:nb_concepts].tolist(),
+        inputs=["This is a sentence", "This is another sentence"],
     )
 
     assert len(label) == nb_concepts
@@ -504,12 +499,12 @@ def test_llm_labels_error_raising(splitted_encoder: ModelWithSplitPoints):
     Test that the `TopKInputs` class raises an error when needed
     """
 
-    concept_model = NeuronsAsConcepts(model_with_split_points=splitted_encoder).concept_model
-
-    method = LLMLabels(
+    concept_explainer = NeuronsAsConcepts(
         model_with_split_points=splitted_encoder,
         split_point="bert.encoder.layer.1.output",
-        concept_model=concept_model,
+    )
+    method = LLMLabels(
+        concept_explainer=concept_explainer,
         activation_granularity=ActivationGranularity.TOKEN,
         use_vocab=False,
         llm_interface=LLMInterfaceMock(),

--- a/tests/concepts/interpretation/test_llm_labels.py
+++ b/tests/concepts/interpretation/test_llm_labels.py
@@ -345,9 +345,7 @@ def test_llm_labels_concept_selection(splitted_encoder: ModelWithSplitPoints):
         ModelWithSplitPoints.activation_granularities.SAMPLE,
     ],
 )
-def test_llm_labels_granularity(
-    splitted_encoder: ModelWithSplitPoints, activation_granularity: ActivationGranularity
-):
+def test_llm_labels_granularity(splitted_encoder: ModelWithSplitPoints, activation_granularity: ActivationGranularity):
     split = "bert.encoder.layer.1.output"
     concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder, split_point=split)
     interpretation_method = LLMLabels(

--- a/tests/concepts/interpretation/test_topk_inputs.py
+++ b/tests/concepts/interpretation/test_topk_inputs.py
@@ -37,6 +37,7 @@ import torch
 
 from interpreto import ModelWithSplitPoints
 from interpreto.concepts import NeuronsAsConcepts
+from interpreto.concepts.base import ConceptEncoderExplainer
 from interpreto.concepts.interpretations import TopKInputs, extract_unique_words
 from interpreto.model_wrapping.model_with_split_points import ActivationGranularity
 
@@ -68,6 +69,16 @@ class ConceptModelCounter:
         return x
 
 
+class DummyConceptExplainer(ConceptEncoderExplainer):
+    """Minimal concept explainer wrapping a concept model for tests."""
+
+    def fit(self, activations, *args, **kwargs):  # pragma: no cover - not used
+        self._ConceptEncoderExplainer__is_fitted = True
+
+    def encode_activations(self, activations):
+        return self.concept_model.encode(activations)
+
+
 def test_topk_inputs_from_activations(splitted_encoder_ml: ModelWithSplitPoints):
     """
     Test that the `_topk_inputs_from_concepts_activations` method works as expected
@@ -92,13 +103,11 @@ def test_topk_inputs_from_activations(splitted_encoder_ml: ModelWithSplitPoints)
     # initializing the explainer
     split = "bert.encoder.layer.1.output"
     splitted_encoder_ml.split_points = split
-    concept_model = NeuronsAsConcepts(model_with_split_points=splitted_encoder_ml, split_point=split).concept_model
+    concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder_ml, split_point=split)
 
     # initializing the interpreter
     interpretation_method = TopKInputs(
-        model_with_split_points=splitted_encoder_ml,
-        split_point=split,
-        concept_model=concept_model,
+        concept_explainer=concept_explainer,
         activation_granularity=AG.TOKEN,
         k=k,
     )
@@ -161,16 +170,14 @@ def test_topk_inputs_granularity(
     # initializing the explainer
     split = "bert.encoder.layer.1.output"
     splitted_encoder_ml.split_points = split
-    concept_model = NeuronsAsConcepts(model_with_split_points=splitted_encoder_ml, split_point=split).concept_model
+    concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder_ml, split_point=split)
 
     # getting the activations
     activations = splitted_encoder_ml.get_activations(huge_text, activation_granularity=activation_granularity)[split]
 
     # initializing the interpreter
     interpretation_method = TopKInputs(
-        model_with_split_points=splitted_encoder_ml,
-        split_point=split,
-        concept_model=concept_model,
+        concept_explainer=concept_explainer,
         activation_granularity=activation_granularity,
         k=2,
     )
@@ -217,10 +224,12 @@ def test_topk_inputs_concepts_selection(splitted_encoder_ml: ModelWithSplitPoint
     activations = splitted_encoder_ml.get_activations(joined_tokens_list, activation_granularity=AG.TOKEN)
 
     # extracting concept interpretations
-    all_top_k_tokens = concept_explainer.interpret(
-        interpretation_method=TopKInputs,
+    interpretation = TopKInputs(
+        concept_explainer=concept_explainer,
         activation_granularity=AG.TOKEN,
         k=k,
+    )
+    all_top_k_tokens = interpretation.interpret(
         concepts_indices="all",
         inputs=joined_tokens_list,
         latent_activations=activations,
@@ -233,10 +242,11 @@ def test_topk_inputs_concepts_selection(splitted_encoder_ml: ModelWithSplitPoint
         assert isinstance(all_top_k_tokens[c], dict) and len(all_top_k_tokens[c]) == k
 
     indices = [0, 2, 4]
-    subset_top_k_tokens = concept_explainer.interpret(
-        interpretation_method=TopKInputs,
+    subset_top_k_tokens = TopKInputs(
+        concept_explainer=concept_explainer,
         activation_granularity=AG.TOKEN,
         k=k,
+    ).interpret(
         concepts_indices=indices,
         inputs=joined_tokens_list,
         latent_activations=activations,
@@ -247,10 +257,11 @@ def test_topk_inputs_concepts_selection(splitted_encoder_ml: ModelWithSplitPoint
         assert subset_top_k_tokens[c] == all_top_k_tokens[c]
 
     index = 0
-    single_top_k_tokens = concept_explainer.interpret(
-        interpretation_method=TopKInputs,
+    single_top_k_tokens = TopKInputs(
+        concept_explainer=concept_explainer,
         activation_granularity=AG.TOKEN,
         k=k,
+    ).interpret(
         concepts_indices=index,
         inputs=joined_tokens_list,
         latent_activations=activations,
@@ -283,25 +294,21 @@ def test_topk_inputs_sources(splitted_encoder_ml: ModelWithSplitPoints):
     activations = splitted_encoder_ml.get_activations(joined_tokens_list, activation_granularity=AG.TOKEN)
 
     # getting the top k tokens
-    top_k_inputs = concept_explainer.interpret(
-        interpretation_method=TopKInputs,
+    interpretation_method = TopKInputs(
+        concept_explainer=concept_explainer,
         activation_granularity=AG.TOKEN,
         k=k,
+    )
+    top_k_inputs = interpretation_method.interpret(
         concepts_indices="all",
         inputs=joined_tokens_list,
     )
-    top_k_latent = concept_explainer.interpret(
-        interpretation_method=TopKInputs,
-        activation_granularity=AG.TOKEN,
-        k=k,
+    top_k_latent = interpretation_method.interpret(
         concepts_indices="all",
         inputs=joined_tokens_list,
         latent_activations=activations,
     )
-    top_k_concept = concept_explainer.interpret(
-        interpretation_method=TopKInputs,
-        activation_granularity=AG.TOKEN,
-        k=k,
+    top_k_concept = interpretation_method.interpret(
         concepts_indices="all",
         inputs=joined_tokens_list,
         concepts_activations=activations[split],
@@ -331,12 +338,13 @@ def test_topk_inputs_from_vocabulary(splitted_encoder_ml: ModelWithSplitPoints):
     splitted_encoder_ml.split_points = split
     concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder_ml, split_point=split)
 
-    top_k_vocabulary = concept_explainer.interpret(
-        interpretation_method=TopKInputs,
+    top_k_vocabulary = TopKInputs(
+        concept_explainer=concept_explainer,
         activation_granularity=AG.TOKEN,
         k=k,
-        concepts_indices=torch.randperm(hidden_size)[:nb_concepts].tolist(),
         use_vocab=True,
+    ).interpret(
+        concepts_indices=torch.randperm(hidden_size)[:nb_concepts].tolist(),
     )
 
     assert len(top_k_vocabulary) == nb_concepts
@@ -371,12 +379,17 @@ def test_topk_inputs_from_unique_words(
     split = "bert.encoder.layer.1.output"
     splitted_encoder_ml.split_points = split
     concept_model = ConceptModelCounter()
+    concept_explainer = DummyConceptExplainer(
+        model_with_split_points=splitted_encoder_ml,
+        concept_model=concept_model,
+        split_point=split,
+    )
+    concept_explainer._ConceptEncoderExplainer__is_fitted = True
     assert concept_model.count == 0
 
     # instantiate the interpreter
     topk_inputs = TopKInputs(
-        model_with_split_points=splitted_encoder_ml,
-        concept_model=concept_model,
+        concept_explainer=concept_explainer,
         activation_granularity=activation_granularity,
         use_unique_words=True,
         k=k,
@@ -416,15 +429,14 @@ def test_topk_inputs_error_raising(
     # getting the activations
     activations = next(iter(activations_dict.values()))  # dictionary with only one element
 
-    concept_model = NeuronsAsConcepts(model_with_split_points=splitted_encoder_ml).concept_model
+    concept_explainer = NeuronsAsConcepts(model_with_split_points=splitted_encoder_ml)
 
     some_texts_for_interpretation = ["a sentence", "another sentence", "yet another sentence"]
 
     # When use_vocab=False and inputs is not provided
     with pytest.raises(ValueError):
         method = TopKInputs(
-            model_with_split_points=splitted_encoder_ml,
-            concept_model=concept_model,
+            concept_explainer=concept_explainer,
             activation_granularity=AG.TOKEN,
             use_vocab=False,
         )
@@ -435,8 +447,7 @@ def test_topk_inputs_error_raising(
     # use_vocab=True and use_unique_words=True
     with pytest.raises(ValueError):
         method = TopKInputs(
-            model_with_split_points=splitted_encoder_ml,
-            concept_model=concept_model,
+            concept_explainer=concept_explainer,
             activation_granularity=AG.TOKEN,
             use_vocab=True,
             use_unique_words=True,
@@ -445,8 +456,7 @@ def test_topk_inputs_error_raising(
     # granularity=CLS_TOKEN and use_unique_words=False
     with pytest.raises(ValueError):
         method = TopKInputs(
-            model_with_split_points=splitted_encoder_ml,
-            concept_model=concept_model,
+            concept_explainer=concept_explainer,
             activation_granularity=AG.CLS_TOKEN,
             use_unique_words=False,
         )
@@ -455,8 +465,7 @@ def test_topk_inputs_error_raising(
     for wrong_indices in [-1, activations.shape[1], [-1, 0, 1], ["?"], (0, 1, 2), "str other than 'all'"]:
         with pytest.raises(ValueError):
             method = TopKInputs(
-                model_with_split_points=splitted_encoder_ml,
-                concept_model=concept_model,
+                concept_explainer=concept_explainer,
                 activation_granularity=AG.TOKEN,
             )
             method.interpret(

--- a/tests/concepts/interpretation/test_topk_inputs.py
+++ b/tests/concepts/interpretation/test_topk_inputs.py
@@ -75,7 +75,7 @@ class DummyConceptExplainer(ConceptEncoderExplainer):
     def fit(self, activations, *args, **kwargs):  # pragma: no cover - not used
         self._ConceptEncoderExplainer__is_fitted = True
 
-    def encode_activations(self, activations):
+    def encode_activations(self, activations):  # type: ignore
         return self.concept_model.encode(activations)
 
 

--- a/tests/concepts/interpretation/test_topk_inputs.py
+++ b/tests/concepts/interpretation/test_topk_inputs.py
@@ -453,14 +453,6 @@ def test_topk_inputs_error_raising(
             use_unique_words=True,
         )
 
-    # granularity=CLS_TOKEN and use_unique_words=False
-    with pytest.raises(ValueError):
-        method = TopKInputs(
-            concept_explainer=concept_explainer,
-            activation_granularity=AG.CLS_TOKEN,
-            use_unique_words=False,
-        )
-
     # wrong indices
     for wrong_indices in [-1, activations.shape[1], [-1, 0, 1], ["?"], (0, 1, 2), "str other than 'all'"]:
         with pytest.raises(ValueError):


### PR DESCRIPTION
Requires #78 

## Description

### Refactor as suggested by #65

Previous API
```python
splitted_model = ModelWithSplitPoints(model, split_point="somewhere")

activations = splitted_model.get_activations(dataset)

concept_explainer = SAEConcepts(splitted_model, nb_concepts=20)

concept_explainer.fit(activations)

# The following line suffers from the aforementioned bug
interpretations = concept_explainer.interpret(TopKInputs, inputs=dataset, latent_activations=activations)

print(interpretations)
```

New API
```python
splitted_model = ModelWithSplitPoints(model, split_point="somewhere")

activations = splitted_model.get_activations(dataset)

concept_explainer = SAEConcepts(splitted_model, nb_concepts=20)

concept_explainer.fit(activations)

interpretation_method = TopKInputs(concept_explainer)
interpretations = interpretation_method.interpret(dataset, activations)

print(interpretations)
```

### Factorize duplicated code

Main part of `interpret` between `TopKInputs` and `LLMLabels` was factorized in `BaseConceptInterpretationMethod.get_granular_inputs_and_concept_activations()`.

### Adds `unique_words_kwargs` to interpretations

This allows the user to perform more complex extraction of unique words, such as filtering less frequent words or lemmatization.


## Related Issue

#65 

## Type of Change

- 📚 Examples / docs / tutorials / dependencies update
- 🔧 Bug fix (non-breaking change which fixes an issue)
- 🥂 Improvement (non-breaking change which improves an existing feature)
- 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
