### PR TITLE
 update of base perturbator and inference wrapper to avoid useless embeddings generation during perturbation

### DIFF
--- a/docs/notebooks/attribution_walkthrough.ipynb
+++ b/docs/notebooks/attribution_walkthrough.ipynb
@@ -3201,7 +3201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "8d8cc361",
    "metadata": {},
    "outputs": [

--- a/interpreto/attributions/methods/kernel_shap.py
+++ b/interpreto/attributions/methods/kernel_shap.py
@@ -99,7 +99,6 @@ class KernelShap(MultitaskExplainerMixin, AttributionExplainer):
 
         perturbator = ShapTokenPerturbator(
             tokenizer=tokenizer,
-            inputs_embedder=model.get_input_embeddings(),
             granularity=granularity,
             replace_token_id=replace_token_id,
             n_perturbations=n_perturbations,

--- a/interpreto/attributions/methods/lime.py
+++ b/interpreto/attributions/methods/lime.py
@@ -44,6 +44,7 @@ from interpreto.attributions.base import AttributionExplainer, InferenceModes, M
 from interpreto.attributions.perturbations.random_perturbation import RandomMaskedTokenPerturbator
 from interpreto.commons import Granularity
 
+
 class Lime(MultitaskExplainerMixin, AttributionExplainer):
     """
     Local Interpretable Model-agnostic Explanations (LIME) is a perturbation‑based approach that explains individual predictions by

--- a/interpreto/attributions/methods/lime.py
+++ b/interpreto/attributions/methods/lime.py
@@ -44,7 +44,6 @@ from interpreto.attributions.base import AttributionExplainer, InferenceModes, M
 from interpreto.attributions.perturbations.random_perturbation import RandomMaskedTokenPerturbator
 from interpreto.commons import Granularity
 
-
 class Lime(MultitaskExplainerMixin, AttributionExplainer):
     """
     Local Interpretable Model-agnostic Explanations (LIME) is a perturbation‑based approach that explains individual predictions by
@@ -107,7 +106,6 @@ class Lime(MultitaskExplainerMixin, AttributionExplainer):
 
         perturbator = RandomMaskedTokenPerturbator(
             tokenizer=tokenizer,
-            inputs_embedder=model.get_input_embeddings(),
             n_perturbations=n_perturbations,
             replace_token_id=replace_token_id,
             granularity=granularity,

--- a/interpreto/attributions/methods/occlusion.py
+++ b/interpreto/attributions/methods/occlusion.py
@@ -94,7 +94,6 @@ class Occlusion(MultitaskExplainerMixin, AttributionExplainer):
 
         perturbator = OcclusionPerturbator(
             tokenizer=tokenizer,
-            inputs_embedder=model.get_input_embeddings(),
             granularity=granularity,
             replace_token_id=replace_token_id,
         )

--- a/interpreto/attributions/methods/sobol_attribution.py
+++ b/interpreto/attributions/methods/sobol_attribution.py
@@ -105,7 +105,6 @@ class Sobol(MultitaskExplainerMixin, AttributionExplainer):
 
         perturbator = SobolTokenPerturbator(
             tokenizer=tokenizer,
-            inputs_embedder=model.get_input_embeddings(),
             granularity=granularity,
             replace_token_id=replace_token_id,
             n_token_perturbations=n_token_perturbations,

--- a/interpreto/attributions/perturbations/__init__.py
+++ b/interpreto/attributions/perturbations/__init__.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .base import TokenMaskBasedPerturbator
+from .base import MaskBasedIdsPerturbator
 from .gaussian_noise_perturbation import GaussianNoisePerturbator
 from .gradient_shap_perturbation import GradientShapPerturbator
 from .linear_interpolation_perturbation import LinearInterpolationPerturbator

--- a/interpreto/attributions/perturbations/base.py
+++ b/interpreto/attributions/perturbations/base.py
@@ -32,8 +32,8 @@ from abc import abstractmethod
 
 import torch
 from beartype import beartype
-from jaxtyping import Float, Int, jaxtyped
-from transformers import PreTrainedTokenizer
+from jaxtyping import Float, Real, jaxtyped
+from transformers.tokenization_utils import PreTrainedTokenizer
 
 from interpreto.commons.granularity import Granularity
 from interpreto.typing import TensorMapping
@@ -43,9 +43,84 @@ class Perturbator:
     """
     Base class for perturbators
     If this class is instantiated, it behaves as a no-op perturbator
-    Perturbators can be defined by subclassing this class and implementing one (or many) of the following methods :
-    - perturb_ids
-    - perturb_embeds
+    Perturbator may be subclassed to define custom perturbations, we recommend to use either IdsPerturbator or EmbeddingsPerturbator as base classes
+    """
+
+    __slots__ = ("_device",)
+
+    @property
+    def device(self) -> torch.device:
+        """
+        Get the device of the perturbator
+        """
+        return self._device if hasattr(self, "_device") else torch.device("cpu")
+
+    @device.setter
+    def device(self, device: torch.device):
+        """
+        Set the device of the perturbator
+        """
+        self._device = device
+
+    def to(self, device: torch.device):
+        """
+        Set the device of the perturbator
+        """
+        self._device = device
+
+    def perturb(self, model_inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
+        """
+        Method called when we ask the perturbator to perturb a mapping of tensors, generally the output of a tokenizer
+        The mapping should be similar to mappings returned by the tokenizer.
+        It should at least have "input_ids" and "attention_mask".
+        Optionally, the "offsets_mapping" might be required for the `SENTENCE` granularity.
+        Give directly the output of the tokenizer without modifying it would be the best and most common way to use this method
+
+        Args:
+            model_inputs (TensorMapping): output of the tokenizers
+        """
+        # add perturbation dimension
+        model_inputs["input_ids"] = model_inputs["input_ids"].unsqueeze(0)
+        if "inputs_embeds" in model_inputs:
+            model_inputs["inputs_embeds"] = model_inputs["inputs_embeds"].unsqueeze(0)
+        # TODO : eventually add perturbation dimension to other keys in the mapping ?
+
+        return model_inputs, torch.zeros_like(model_inputs["input_ids"], dtype=torch.float)
+
+    def __call__(self, model_inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
+        return self.perturb(model_inputs)
+
+
+class IdsPerturbator(Perturbator):
+    """
+    Specific abstract class for perturbators working on input IDs
+    All perturbators working on input IDs only should inherit from this class
+    """
+
+    def perturb(self, model_inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
+        return self.perturb_ids(model_inputs)
+
+    @abstractmethod
+    @jaxtyped(typechecker=beartype)
+    def perturb_ids(self, model_inputs: TensorMapping) -> tuple[TensorMapping, Float[torch.Tensor, "p g"] | None]:
+        """
+        Perturb the input of the model, given as token ids
+
+        Args:
+            model_inputs (MutableMapping): Mapping given by the tokenizer, should contain "input_ids"
+
+        Returns:
+            TensorMapping: Perturbed mapping
+            Float[torch.Tensor, "p g"] | None: Perturbation mask, if applicable
+        """
+        model_inputs["input_ids"] = model_inputs["input_ids"].unsqueeze(0)
+        return model_inputs, torch.zeros_like(model_inputs["input_ids"], dtype=torch.float)
+
+
+class EmbeddingsPerturbator(Perturbator):
+    """
+    Specific abstract class for perturbators working on input embeddings
+    All perturbators working on input embeddings only should inherit from this class
     """
 
     __slots__ = ("inputs_embedder",)
@@ -57,7 +132,6 @@ class Perturbator:
             inputs_embedder: Optional module used to embed input IDs when only
                 ``input_ids`` are provided.
         """
-
         # Embedders is optional
         self.inputs_embedder = inputs_embedder
 
@@ -68,7 +142,7 @@ class Perturbator:
         """
         if self.inputs_embedder is not None:
             return self.inputs_embedder.weight.device  # type: ignore
-        return torch.device("cpu")
+        return self._device
 
     @device.setter
     def device(self, device: torch.device):
@@ -77,6 +151,7 @@ class Perturbator:
         """
         if self.inputs_embedder is not None:
             self.inputs_embedder.to(device)
+        self._device = device
 
     def to(self, device: torch.device):
         """
@@ -84,7 +159,23 @@ class Perturbator:
         """
         self.device = device
 
-    # TODO : this function is replicated in the inference wrapper, enventually merge them
+    def perturb(self, model_inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
+        embeddings = self._embed(model_inputs)
+        return self.perturb_embeds(embeddings)
+
+    @abstractmethod
+    def perturb_embeds(self, model_inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
+        """
+        Perturb the input of the model, given as embeddings
+
+        Args:
+            model_inputs (MutableMapping): Mapping given by the tokenizer, should contain "inputs_embeds", otherwise, the given inputs_embedder will be used to compute them from "input_ids"
+        Returns:
+            TensorMapping: Perturbed mapping
+            torch.Tensor | None: Perturbation mask, if applicable
+        """
+
+    # TODO : this function is replicated in the inference wrapper, eventually merge them
     def _embed(self, model_inputs: TensorMapping) -> TensorMapping:
         """
         Embed the inputs using the inputs_embedder
@@ -113,86 +204,38 @@ class Perturbator:
         # If neither input ids nor input embeds are present, raise an error
         raise ValueError("model_inputs should contain either 'input_ids' or 'inputs_embeds'")
 
-    # TODO: see if needed (not used by explainers)
-    # @overload
-    # def perturb(self, inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
-    #     """
-    #     base implementation
-    #     """
 
-    # @overload
-    # def perturb(
-    #     self, inputs: NestedIterable[TensorMapping]
-    # ) -> NestedIterable[tuple[TensorMapping, torch.Tensor | None]]:
-    #     """
-    #     overload for nested iterable of inputs
-    #     handled by the allow_nested_iterables_of decorator
-    #     """
-
-    # @allow_nested_iterables_of(MutableMapping)
-    def perturb(self, inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
-        """
-        Method called when we ask the perturbator to perturb a mapping of tensors, generally the output of a tokenizer
-        The mapping should be similar to mappings returned by the tokenizer.
-        It should at least have "input_ids" and "attention_mask".
-        Optionally, it "offsets_mapping" might be required for the `SENTENCE` granularity.
-        Give directly the output of the tokenizer without modifying it would be the best and most common way to use this method
-
-        Args:
-            inputs (TensorMapping): output of the tokenizers
-        """
-        mask = None
-        if "input_ids" in inputs:
-            # Call the tokens perturbation on the inputs ids
-            inputs, mask = self.perturb_ids(inputs)
-
-        try:
-            # TODO : perform smart combination of perturbation masks on ids and on embeddings !
-            # inputs, ids_pert_mask = self.perturb_embeds(self._embed(inputs))
-            # final_mask = some_combination(ids_pert_mask, embeds_pert_mask) # something like a elementwise binary or on the tensors ?
-            # return inputs, final_mask
-            embeddings = self._embed(
-                inputs.copy()  # type: ignore
-            )  # copy is necessary otherwise inputs are embedded even if an error is raised
-            return self.perturb_embeds(embeddings)
-        except (ValueError, NotImplementedError):
-            return (inputs, mask)
-
-    @jaxtyped(typechecker=beartype)
-    def perturb_ids(self, model_inputs: TensorMapping) -> tuple[TensorMapping, Float[torch.Tensor, "p g"] | None]:
-        """
-        Perturb the input of the model
-
-        Args:
-            model_inputs (MutableMapping): Mapping given by the tokenizer
-
-        Returns:
-            TensorMapping: Perturbed mapping
-            Float[torch.Tensor, "p g"] | None: Perturbation mask, if applicable
-        """
-        # add perturbation dimension
-        return model_inputs, torch.zeros_like(model_inputs["input_ids"], dtype=torch.float)
-
-    def perturb_embeds(self, model_inputs: TensorMapping) -> tuple[TensorMapping, torch.Tensor | None]:
-        # inputs["attention_mask"] = inputs["attention_mask"].unsqueeze(1).repeat(1, embeddings.shape[1], 1)
-        raise NotImplementedError(f"No way to perturb input embeddings has been defined in {self.__class__.__name__}")
-
-
-class MaskBasedPerturbator(Perturbator):
+class MaskBasedIdsPerturbator(IdsPerturbator):
     """
-    Base class for methods applying a mask to the input
-    This class is just furnishing a default implementation for the apply_mask method
-    This class should not be subclasses by perturbation methods.
-    Please consider using TokenMaskBasedPerturbator or EmbeddingsMaskBasedPerturbator instead, depending on where you want to apply your mask
+    Base class for perturbations consisting in applying masks on token (or groups of tokens)
     """
 
-    __slots__ = ()
+    __slots__ = ("tokenizer", "n_perturbations", "replace_token_id", "granularity")
 
-    @jaxtyped(typechecker=beartype)
-    def apply_mask(
+    def __init__(
         self,
-        inputs: Int[torch.Tensor, "l d"] | Float[torch.Tensor, "l d"],
-        mask: Float[torch.Tensor, "p g"],
+        tokenizer: PreTrainedTokenizer | None,
+        replace_token_id: int,
+        n_perturbations: int = 1,
+        granularity: Granularity = Granularity.TOKEN,
+    ):
+        self.tokenizer = tokenizer
+
+        # number of perturbations made by the "perturb" method
+        self.n_perturbations = n_perturbations
+
+        # token id used to replace the masked tokens
+        self.replace_token_id = replace_token_id
+
+        # granularity level of the perturbation (token masking, word masking...)
+        # in most commons cases, this should be set to Granularity.TOKEN
+        self.granularity = granularity
+
+    @jaxtyped(typechecker=beartype)
+    @staticmethod
+    def apply_mask(
+        inputs: Real[torch.Tensor, "l d"],
+        mask: Real[torch.Tensor, "p g"],
         mask_value: torch.Tensor,
     ) -> Float[torch.Tensor, "p l d"] | Float[torch.Tensor, "p l"]:
         """
@@ -209,44 +252,17 @@ class MaskBasedPerturbator(Perturbator):
         Returns:
             torch.Tensor: masked inputs
         """
-        # TODO generalize to upper dimensions for other types of input data
-        base: Float[torch.Tensor, "p l d"] = torch.einsum("ld,pl->pld", inputs, 1 - mask)
-        masked: Float[torch.Tensor, "p l d"] = torch.einsum("pl,d->pld", mask, mask_value)
+        base: Real[torch.Tensor, "p l d"] = inputs.unsqueeze(-3) * (1 - mask).unsqueeze(
+            -1
+        )  # torch.einsum("ld,pl->pld", inputs, 1 - mask)
+        masked: Real[torch.Tensor, "p l d"] = mask_value * mask.unsqueeze(
+            -1
+        )  # torch.einsum("pl,d->pld", mask, mask_value)
         return (base + masked).squeeze(-1)
-
-
-class TokenMaskBasedPerturbator(MaskBasedPerturbator):
-    """
-    Base class for perturbations consisting in applying masks on token (or groups of tokens)
-    """
-
-    __slots__ = ("tokenizer", "n_perturbations", "replace_token_id", "granularity")
-
-    def __init__(
-        self,
-        tokenizer: PreTrainedTokenizer | None,
-        replace_token_id: int,
-        inputs_embedder: torch.nn.Module | None = None,
-        n_perturbations: int = 1,
-        granularity: Granularity = Granularity.TOKEN,
-    ):
-        super().__init__(inputs_embedder=inputs_embedder)
-
-        self.tokenizer = tokenizer
-
-        # number of perturbations made by the "perturb" method
-        self.n_perturbations = n_perturbations
-
-        # token id used to replace the masked tokens
-        self.replace_token_id = replace_token_id
-
-        # granularity level of the perturbation (token masking, word masking...)
-        # in most commons cases, this should be set to Granularity.TOKEN
-        self.granularity = granularity
 
     @jaxtyped(typechecker=beartype)
     @abstractmethod
-    def get_mask(self, mask_dim: int) -> Float[torch.Tensor, "{self.n_perturbations} {mask_dim}"]:
+    def get_mask(self, mask_dim: int) -> Real[torch.Tensor, "{self.n_perturbations} {mask_dim}"]:
         """
         Method returning a perturbation mask for a given set of inputs
         This method should be implemented in subclasses
@@ -282,17 +298,17 @@ class TokenMaskBasedPerturbator(MaskBasedPerturbator):
             )
 
         # compute association matrix between the granularity level and ALL_TOKENS
-        association_matrix: Float[torch.Tensor, "g l"] = (
+        association_matrix: Real[torch.Tensor, "g l"] = (
             Granularity.get_association_matrix(model_inputs, self.granularity, self.tokenizer)[0]
             .float()
             .to(self.device)
         )
 
         # compute granularity-wise perturbation mask based on the length of the sequence (granularity-wise)
-        gran_mask: Float[torch.Tensor, "p g"] = self.get_mask(association_matrix.shape[0]).to(self.device)
+        gran_mask: Real[torch.Tensor, "p g"] = self.get_mask(association_matrix.shape[0]).to(self.device)
 
         # compute real perturbation mask
-        real_mask: Float[torch.Tensor, "p l"] = torch.einsum("pg,gl->pl", gran_mask, association_matrix)
+        real_mask: Real[torch.Tensor, "p l"] = torch.einsum("pg,gl->pl", gran_mask, association_matrix)
 
         model_inputs["input_ids"] = (
             self.apply_mask(
@@ -311,48 +327,3 @@ class TokenMaskBasedPerturbator(MaskBasedPerturbator):
                 repeats[0] = model_inputs["input_ids"].shape[0]
                 model_inputs[k] = model_inputs[k].repeat(*repeats)
         return model_inputs, gran_mask
-
-
-# class EmbeddingsMaskBasedPerturbator(MaskBasedPerturbator):
-#     """
-#     Base class for perturbations consisting in applying masks on embeddings
-#     """
-
-#     __slots__ = ("replacement_vector", "n_perturbations")
-
-#     def __init__(
-#         self,
-#         inputs_embedder: torch.nn.Module | None = None,
-#         n_perturbations: int = 1,
-#         replacement_vector: torch.Tensor | None = None,
-#     ):
-#         super().__init__(inputs_embedder=inputs_embedder)
-#         self.n_perturbations = n_perturbations
-#         self.replacement_vector = replacement_vector
-
-#     def get_mask(self, embeddings: torch.Tensor) -> torch.Tensor:
-#         """
-#         Method returning a perturbation mask for a given set of embeddings
-#         This method should be implemented in subclasses
-
-#         Args:
-#             embeddings (torch.Tensor): embeddings to perturb
-
-#         Returns:
-#             torch.Tensor: mask to apply
-#         """
-#         raise NotImplementedError(f"Method get_mask not implemented in {self.__class__.__name__}")
-
-#     def perturb_embeds(
-#         self, model_inputs: MutableMapping
-#     ) -> tuple[TensorMapping, torch.Tensor | None]:
-#         replacement_vector = self.replacement_vector
-#         if replacement_vector is None:
-#             replacement_vector = torch.zeros(
-#                 model_inputs["inputs_embeds"].shape[-1], device=model_inputs["inputs_embeds"].device
-#             )
-
-#         embeddings = model_inputs["inputs_embeds"]
-#         mask = self.get_mask(embeddings)
-#         model_inputs["inputs_embeds"] = self.apply_mask(embeddings, mask, replacement_vector)
-#         return model_inputs, mask

--- a/interpreto/attributions/perturbations/gaussian_noise_perturbation.py
+++ b/interpreto/attributions/perturbations/gaussian_noise_perturbation.py
@@ -28,11 +28,11 @@ import torch
 from beartype import beartype
 from jaxtyping import Float, jaxtyped
 
-from interpreto.attributions.perturbations.base import Perturbator
+from interpreto.attributions.perturbations.base import EmbeddingsPerturbator
 from interpreto.typing import TensorMapping
 
 
-class GaussianNoisePerturbator(Perturbator):
+class GaussianNoisePerturbator(EmbeddingsPerturbator):
     """
     Perturbator adding gaussian noise to the input tensor
     """

--- a/interpreto/attributions/perturbations/linear_interpolation_perturbation.py
+++ b/interpreto/attributions/perturbations/linear_interpolation_perturbation.py
@@ -28,11 +28,11 @@ import torch
 from beartype import beartype
 from jaxtyping import Float, Int64, jaxtyped
 
-from interpreto.attributions.perturbations.base import Perturbator
+from interpreto.attributions.perturbations.base import EmbeddingsPerturbator
 from interpreto.typing import TensorBaseline, TensorMapping
 
 
-class LinearInterpolationPerturbator(Perturbator):
+class LinearInterpolationPerturbator(EmbeddingsPerturbator):
     """
     Perturbation using linear interpolation between a reference point (baseline) and the input.
     This class can serve as a base for different interpolation-based perturbators.

--- a/interpreto/attributions/perturbations/occlusion_perturbation.py
+++ b/interpreto/attributions/perturbations/occlusion_perturbation.py
@@ -29,11 +29,11 @@ from beartype import beartype
 from jaxtyping import Float, jaxtyped
 from transformers import PreTrainedTokenizer
 
-from interpreto.attributions.perturbations.base import TokenMaskBasedPerturbator
+from interpreto.attributions.perturbations.base import MaskBasedIdsPerturbator
 from interpreto.commons.granularity import Granularity
 
 
-class OcclusionPerturbator(TokenMaskBasedPerturbator):
+class OcclusionPerturbator(MaskBasedIdsPerturbator):
     """
     Basic class for occlusion perturbations
     """
@@ -43,7 +43,6 @@ class OcclusionPerturbator(TokenMaskBasedPerturbator):
     def __init__(
         self,
         tokenizer: PreTrainedTokenizer | None = None,
-        inputs_embedder: torch.nn.Module | None = None,
         granularity: Granularity = Granularity.TOKEN,
         replace_token_id: int = 0,
     ) -> None:
@@ -59,7 +58,6 @@ class OcclusionPerturbator(TokenMaskBasedPerturbator):
         super().__init__(
             tokenizer=tokenizer,
             replace_token_id=replace_token_id,
-            inputs_embedder=inputs_embedder,
             n_perturbations=-1,
             granularity=granularity,
         )

--- a/interpreto/attributions/perturbations/random_perturbation.py
+++ b/interpreto/attributions/perturbations/random_perturbation.py
@@ -34,10 +34,10 @@ from jaxtyping import Float, jaxtyped
 from torch import Tensor
 from transformers import PreTrainedTokenizer
 
-from interpreto.attributions.perturbations.base import Granularity, TokenMaskBasedPerturbator
+from interpreto.attributions.perturbations.base import Granularity, MaskBasedIdsPerturbator
 
 
-class RandomMaskedTokenPerturbator(TokenMaskBasedPerturbator):
+class RandomMaskedTokenPerturbator(MaskBasedIdsPerturbator):
     """
     Perturbator adding random masking to the input tensor
     """
@@ -45,7 +45,6 @@ class RandomMaskedTokenPerturbator(TokenMaskBasedPerturbator):
     def __init__(
         self,
         tokenizer: PreTrainedTokenizer | None = None,
-        inputs_embedder: torch.nn.Module | None = None,
         granularity: Granularity = Granularity.TOKEN,
         replace_token_id: int = 0,
         n_perturbations: int = 30,
@@ -63,7 +62,6 @@ class RandomMaskedTokenPerturbator(TokenMaskBasedPerturbator):
         """
         super().__init__(
             tokenizer=tokenizer,
-            inputs_embedder=inputs_embedder,
             n_perturbations=n_perturbations,
             replace_token_id=replace_token_id,
             granularity=granularity,

--- a/interpreto/attributions/perturbations/shap_perturbation.py
+++ b/interpreto/attributions/perturbations/shap_perturbation.py
@@ -34,15 +34,14 @@ from jaxtyping import Float, jaxtyped
 from torch import Tensor
 from transformers import PreTrainedTokenizer
 
-from interpreto.attributions.perturbations.base import TokenMaskBasedPerturbator
+from interpreto.attributions.perturbations.base import MaskBasedIdsPerturbator
 from interpreto.commons.granularity import Granularity
 
 
-class ShapTokenPerturbator(TokenMaskBasedPerturbator):
+class ShapTokenPerturbator(MaskBasedIdsPerturbator):
     def __init__(
         self,
         tokenizer: PreTrainedTokenizer | None = None,
-        inputs_embedder: torch.nn.Module | None = None,
         granularity: Granularity = Granularity.TOKEN,
         replace_token_id: int = 0,
         n_perturbations: int = 1000,
@@ -60,7 +59,6 @@ class ShapTokenPerturbator(TokenMaskBasedPerturbator):
         """
         super().__init__(
             tokenizer=tokenizer,
-            inputs_embedder=inputs_embedder,
             n_perturbations=n_perturbations,
             replace_token_id=replace_token_id,
             granularity=granularity,

--- a/interpreto/attributions/perturbations/sobol_perturbation.py
+++ b/interpreto/attributions/perturbations/sobol_perturbation.py
@@ -36,7 +36,7 @@ from jaxtyping import Float, jaxtyped
 from scipy.stats import qmc
 from transformers import PreTrainedTokenizer
 
-from interpreto.attributions.perturbations.base import TokenMaskBasedPerturbator
+from interpreto.attributions.perturbations.base import MaskBasedIdsPerturbator
 from interpreto.commons.granularity import Granularity
 
 
@@ -50,11 +50,10 @@ class SequenceSamplers(Enum):
     LatinHypercube = qmc.LatinHypercube
 
 
-class SobolTokenPerturbator(TokenMaskBasedPerturbator):
+class SobolTokenPerturbator(MaskBasedIdsPerturbator):
     def __init__(
         self,
         tokenizer: PreTrainedTokenizer | None = None,
-        inputs_embedder: torch.nn.Module | None = None,
         granularity: Granularity = Granularity.TOKEN,
         replace_token_id: int = 0,
         n_token_perturbations: int = 30,
@@ -72,7 +71,6 @@ class SobolTokenPerturbator(TokenMaskBasedPerturbator):
         """
         super().__init__(
             tokenizer=tokenizer,
-            inputs_embedder=inputs_embedder,
             granularity=granularity,
             n_perturbations=-1,  # TODO: find a better way to handle this, I guess, it should not be an attribute of the parent class
             replace_token_id=replace_token_id,

--- a/interpreto/commons/granularity.py
+++ b/interpreto/commons/granularity.py
@@ -28,9 +28,9 @@ Definition of different granularity levels for explainers (tokens, words, senten
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from enum import Enum
 from functools import lru_cache
-from typing import Protocol
 
 import torch
 from beartype import beartype
@@ -85,22 +85,7 @@ class GranularityAggregationStrategy(Enum):
     SIGNED_MAX = staticmethod(lambda x, dim: x.gather(dim, x.abs().argmax(dim=dim).unsqueeze(dim)))
 
 
-class AggregationProtocol(Protocol):
-    """Protocol for aggregation strategies used in :meth:`ModelWithSplitPoints.get_activations`."""
-
-    def __call__(self, x: torch.Tensor, dim: int) -> torch.Tensor:
-        """Aggregate activations.
-
-        Args:
-            x (torch.Tensor): The tensor to aggregate.
-
-        Returns:
-            torch.Tensor: The aggregated tensor.
-        """
-        ...
-
-
-class Granularity:
+class Granularity(Enum):
     """
     Enumerations of the different granularity levels supported for masking perturbations
     Allows to define token-wise masking, word-wise masking...
@@ -112,7 +97,6 @@ class Granularity:
     SENTENCE = "sentence"  # Sentences of the input
     # PARAGRAPH = "paragraph"  # Not supported yet, the "\n\n" characters are replaced by spaces in many tokenizers.
     DEFAULT = ALL_TOKENS
-    aggregation_strategies = GranularityAggregationStrategy
 
     @staticmethod
     # @jaxtyped(typechecker=beartype)
@@ -245,18 +229,18 @@ class Granularity:
                 raise NotImplementedError(f"Granularity level {granularity} not implemented")
 
     @staticmethod
-    def __all_tokens_get_indices(tokens_ids) -> list[list[int]]:
+    def __all_tokens_get_indices(tokens_ids: torch.Tensor) -> list[list[int]]:
         """Indices for :pyattr:`ALL_TOKENS` – every position kept."""
         length = len(tokens_ids)
         return [[i] for i in range(length)]
 
     @staticmethod
-    def __token_get_indices(tokens_ids, special_ids) -> list[list[int]]:
+    def __token_get_indices(tokens_ids: torch.Tensor, special_ids: list[int]) -> list[list[int]]:
         """Indices for :pyattr:`TOKEN` – skip special tokens."""
         return [[i] for i, tok_id in enumerate(tokens_ids) if tok_id not in special_ids]
 
     @staticmethod
-    def __word_get_indices(word_ids) -> list[list[int]]:
+    def __word_get_indices(word_ids: torch.Tensor) -> list[list[int]]:
         """Indices for :pyattr:`WORD` – group tokens belonging to the same word."""
         mapping: dict[int, list[int]] = {}
         for idx, wid in enumerate(word_ids):
@@ -419,7 +403,7 @@ class Granularity:
     def aggregate_score_for_gradient_method(
         contribution: torch.Tensor,
         granularity: Granularity | None,
-        granularity_aggregation_strategy: AggregationProtocol | None = None,
+        granularity_aggregation_strategy: Callable[[torch.Tensor, int], torch.Tensor] | None = None,
         inputs: BatchEncoding | None = None,
         tokenizer: PreTrainedTokenizer | None = None,
     ) -> Float[torch.Tensor, "t g"]:

--- a/interpreto/model_wrapping/model_with_split_points.py
+++ b/interpreto/model_wrapping/model_with_split_points.py
@@ -24,6 +24,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import Enum
 from typing import Any
 
@@ -42,7 +43,7 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.tokenization_utils_base import BatchEncoding
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 
-from interpreto.commons.granularity import AggregationProtocol, Granularity, GranularityAggregationStrategy
+from interpreto.commons.granularity import Granularity, GranularityAggregationStrategy
 from interpreto.model_wrapping.splitting_utils import get_layer_by_idx, sort_paths, validate_path, walk_modules
 from interpreto.model_wrapping.transformers_classes import (
     get_supported_hf_transformer_autoclasses,
@@ -320,7 +321,7 @@ class ModelWithSplitPoints(LanguageModel):
         inputs: BatchEncoding | torch.Tensor,
         activations: Float[torch.Tensor, "n l d"],
         activation_granularity: ActivationGranularity,
-        aggregation_strategy: AggregationProtocol,
+        aggregation_strategy: Callable[[torch.Tensor, int], torch.Tensor],
     ) -> torch.Tensor:
         """Apply selection strategy to activations.
 
@@ -329,7 +330,7 @@ class ModelWithSplitPoints(LanguageModel):
                 In the case of a `torch.Tensor`, we assume a batch dimension and token ids.
             activations (InterventionProxy): Activations to apply selection strategy to.
             activation_granularity (ActivationGranularity): Selection strategy to apply. see :meth:`ModelWithSplitPoints.get_activations`.
-            aggregation_strategy (AggregationProtocol): Aggregation strategy to apply. see :meth:`ModelWithSplitPoints.get_activations`.
+            aggregation_strategy (Callable[[torch.Tensor, int], torch.Tensor]): Aggregation strategy to apply. see :meth:`ModelWithSplitPoints.get_activations`.
 
         Returns:
             torch.Tensor: The aggregated activations.
@@ -418,7 +419,7 @@ class ModelWithSplitPoints(LanguageModel):
         self,
         inputs: list[str] | torch.Tensor | BatchEncoding,
         activation_granularity: ActivationGranularity = ActivationGranularity.ALL_TOKENS,
-        aggregation_strategy: AggregationProtocol = GranularityAggregationStrategy.MEAN,
+        aggregation_strategy: Callable[[torch.Tensor, int], torch.Tensor] = GranularityAggregationStrategy.MEAN,
         pad_side: str = "left",
         **kwargs,
     ) -> dict[str, LatentActivations]:

--- a/tests/attributions/methods/test_attribution_methods_NLP.py
+++ b/tests/attributions/methods/test_attribution_methods_NLP.py
@@ -48,7 +48,7 @@ from interpreto.attributions import (
     VarGrad,
 )
 from interpreto.attributions.base import AttributionOutput
-from interpreto.commons.granularity import _HAS_SPACY, Granularity
+from interpreto.commons.granularity import _HAS_SPACY, Granularity, GranularityAggregationStrategy
 from interpreto.model_wrapping.inference_wrapper import InferenceModes
 from interpreto.typing import IncompatibilityError
 
@@ -173,10 +173,10 @@ def test_attribution_methods_granularity(model_name, attribution_explainer, gran
 @pytest.mark.parametrize(
     "aggregation_strategy",
     [
-        Granularity.aggregation_strategies.MAX,
-        Granularity.aggregation_strategies.MIN,
-        Granularity.aggregation_strategies.SUM,
-        Granularity.aggregation_strategies.SIGNED_MAX,
+        GranularityAggregationStrategy.MAX,
+        GranularityAggregationStrategy.MIN,
+        GranularityAggregationStrategy.SUM,
+        GranularityAggregationStrategy.SIGNED_MAX,
     ],
 )
 def test_attribution_methods_granularity_aggregation_strategy(
@@ -290,10 +290,6 @@ def evaluate_attribution_methods_with_text(model_name, attribution_explainer, gr
             len(attribution.elements) == (attribution.attributions).shape[-1] for attribution in attributions
         ), "In the AttributionOutput class, elements and attributions must have the same length."
 
-
-# TODO: test granularity
-
-# TODO: test inference_mode
 
 # TODO: test that targets are correctly processed
 

--- a/tests/attributions/perturbations/test_perturbators.py
+++ b/tests/attributions/perturbations/test_perturbators.py
@@ -21,7 +21,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from collections.abc import Iterable, MutableMapping
+from collections.abc import MutableMapping
 
 import pytest
 import torch
@@ -93,7 +93,6 @@ def test_token_perturbators(perturbator_class, sentences, bert_model, bert_token
     """test all perturbators respect the API"""
     assert issubclass(perturbator_class, MaskBasedIdsPerturbator)
     p = 10
-    inputs_embedder = bert_model.get_input_embeddings()
 
     replace_token = "[REPLACE]"
     if replace_token not in bert_tokenizer.get_vocab():

--- a/tests/attributions/perturbations/test_perturbators.py
+++ b/tests/attributions/perturbations/test_perturbators.py
@@ -21,8 +21,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from collections.abc import MutableMapping
+from collections.abc import Iterable, MutableMapping
 
 import pytest
 import torch
@@ -36,7 +35,7 @@ from interpreto.attributions.perturbations import (
     ShapTokenPerturbator,
     SobolTokenPerturbator,
 )
-from interpreto.attributions.perturbations.base import TokenMaskBasedPerturbator
+from interpreto.attributions.perturbations.base import MaskBasedIdsPerturbator
 from interpreto.attributions.perturbations.sobol_perturbation import SequenceSamplers
 from interpreto.commons.granularity import Granularity
 
@@ -59,7 +58,7 @@ DEVICE = torch.device("cuda") if torch.cuda.is_available() else torch.device("cp
 @pytest.mark.parametrize("perturbator_class", embeddings_perturbators)
 def test_embeddings_perturbators(perturbator_class, sentences, bert_model, bert_tokenizer):
     """test all perturbators respect the API"""
-    assert not issubclass(perturbator_class, TokenMaskBasedPerturbator)
+    assert not issubclass(perturbator_class, MaskBasedIdsPerturbator)
     p = 10
     d = 32
     inputs_embedder = bert_model.get_input_embeddings()
@@ -92,7 +91,7 @@ def test_embeddings_perturbators(perturbator_class, sentences, bert_model, bert_
 @pytest.mark.parametrize("perturbator_class", tokens_perturbators)
 def test_token_perturbators(perturbator_class, sentences, bert_model, bert_tokenizer):
     """test all perturbators respect the API"""
-    assert issubclass(perturbator_class, TokenMaskBasedPerturbator)
+    assert issubclass(perturbator_class, MaskBasedIdsPerturbator)
     p = 10
     inputs_embedder = bert_model.get_input_embeddings()
 
@@ -106,14 +105,12 @@ def test_token_perturbators(perturbator_class, sentences, bert_model, bert_token
         # the number of perturbations depends on the sequence length
         perturbator = perturbator_class(
             tokenizer=bert_tokenizer,
-            inputs_embedder=inputs_embedder,
             granularity=Granularity.ALL_TOKENS,
             replace_token_id=replace_token_id,
         )
     else:
         perturbator = perturbator_class(
             tokenizer=bert_tokenizer,
-            inputs_embedder=inputs_embedder,
             granularity=Granularity.ALL_TOKENS,
             replace_token_id=replace_token_id,
             n_perturbations=p,
@@ -152,11 +149,50 @@ def test_token_perturbators(perturbator_class, sentences, bert_model, bert_token
         assert perturbed_inputs["attention_mask"].shape == (real_p, l)
 
 
-# TODO: test apply mask
+def test_basic_mask_based_methods():
+    # basic test data
+    sequence_length = 4
+    embedding_dim = 5
+    nb_perturbations = 2
 
-# TODO: test granularity functions and resulting masks
+    embeddings = torch.ones(sequence_length, embedding_dim)
+    ids = torch.ones(sequence_length, 1)
 
-# TODO: test granularity perturbation application on inputs
+    # basic masks and mask values
+    mask_id = torch.rand(1)
+    mask_embed = torch.rand(embedding_dim)
+    all_mask = torch.ones(1, sequence_length)
+    no_mask = torch.zeros(1, sequence_length)
+    float_mask = torch.rand(nb_perturbations, sequence_length)
+    binary_mask = (float_mask > 0.5).float()
+
+    # tests
+    assert torch.equal(
+        MaskBasedIdsPerturbator.apply_mask(embeddings, all_mask, mask_embed),
+        mask_embed.reshape(1, 1, embedding_dim).repeat(1, sequence_length, 1),
+    )
+    assert torch.equal(MaskBasedIdsPerturbator.apply_mask(embeddings, no_mask, mask_embed), embeddings.unsqueeze(0))
+    assert torch.equal(
+        MaskBasedIdsPerturbator.apply_mask(ids, all_mask, mask_id),
+        (mask_id * torch.ones_like(ids)).unsqueeze(0).squeeze(-1),
+    )
+    assert torch.equal(MaskBasedIdsPerturbator.apply_mask(ids, no_mask, mask_id), ids.unsqueeze(0).squeeze(-1))
+    assert torch.equal(
+        MaskBasedIdsPerturbator.apply_mask(ids, float_mask, mask_id),
+        (ids.unsqueeze(0) * (1 - float_mask).unsqueeze(-1) + mask_id * float_mask.unsqueeze(-1)).squeeze(-1),
+    )
+    assert torch.equal(
+        MaskBasedIdsPerturbator.apply_mask(ids, binary_mask, mask_id),
+        (ids.unsqueeze(0) * (1 - binary_mask).unsqueeze(-1) + mask_id * binary_mask.unsqueeze(-1)).squeeze(-1),
+    )
+    assert torch.equal(
+        MaskBasedIdsPerturbator.apply_mask(embeddings, float_mask, mask_embed),
+        embeddings.unsqueeze(0) * (1 - float_mask).unsqueeze(-1) + mask_embed * float_mask.unsqueeze(-1),
+    )
+    assert torch.equal(
+        MaskBasedIdsPerturbator.apply_mask(embeddings, binary_mask, mask_embed),
+        embeddings.unsqueeze(0) * (1 - binary_mask).unsqueeze(-1) + mask_embed * binary_mask.unsqueeze(-1),
+    )
 
 
 def test_linear_interpolation_perturbation_adjust_baseline():
@@ -238,7 +274,6 @@ def test_linear_interpolation_perturbation_adjust_baseline_invalid():
 def test_sobol_masks(sampler):
     k = 10
     perturbator = SobolTokenPerturbator(
-        inputs_embedder=None,
         n_token_perturbations=k,
         sampler=sampler,
     )
@@ -260,7 +295,7 @@ def test_sobol_masks(sampler):
 
 
 def test_occlusion_masks():
-    perturbator = OcclusionPerturbator(inputs_embedder=None)
+    perturbator = OcclusionPerturbator()
     for l in range(2, 20, 3):
         mask = perturbator.get_mask(l)
         assert torch.equal(mask, torch.cat([torch.zeros(1, l), torch.eye(l)], dim=0))
@@ -273,6 +308,8 @@ if __name__ == "__main__":
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
         "Interpreto is magical",
         "Testing interpreto",
+        "Magma is a bad album",
+        "This is a string mith multiples sentences. I assume it works too! Right? I hope so.",
     ]
     bert_model = AutoModelForSequenceClassification.from_pretrained("hf-internal-testing/tiny-random-bert")
     bert_tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")


### PR DESCRIPTION
## Description

- update of base perturbator and inference wrapper to avoid useless embeddings generation during perturbation
- test of mask application for mask based perturbators

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

Related to #2 (see if more tests are needed

<!-- Keep only the ones that apply -->

- 🥂 Improvement (non-breaking change which improves an existing feature)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
