### PR TITLE
Introduce a bump version script and `make bump-version` command

### DIFF
--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -66,18 +66,9 @@ current_version=${current_version%\"}
 IFS='.' read -r major minor patch <<<"$current_version"
 
 case "$part" in
-    major)
-        ((major++))
-        minor=0
-        patch=0
-        ;;
-    minor)
-        ((minor++))
-        patch=0
-        ;;
-    patch)
-        ((patch++))
-        ;;
+  major) ((++major)); minor=0; patch=0 ;;
+  minor) ((++minor)); patch=0 ;;
+  patch) ((++patch)) ;;
 esac
 
 next_version="${major}.${minor}.${patch}"

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -56,8 +56,8 @@ version_line=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || t
 if [[ -z "$version_line" ]]; then
     error "Could not find a semantic version in pyproject.toml."
 fi
-current_version=${version_line#version = "}
-current_version=${current_version%"}
+current_version=${version_line#version = \"}
+current_version=${current_version%\"}
 IFS='.' read -r major minor patch <<<"$current_version"
 
 case "$part" in

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Make ERRs visible (even inside functions/command substitutions)
+set -E -o errtrace
+trap 'rc=$?; echo -e "${RED}Error:${RESET} command \"${BASH_COMMAND}\" failed with exit $rc at line $LINENO"; exit $rc' ERR
+
+
 RED="\033[31m"
 GREEN="\033[32m"
 RESET="\033[0m"
@@ -52,25 +57,13 @@ if ! git merge-base --is-ancestor origin/main HEAD; then
     error "Current branch is not up to date with origin/main. Please rebase or merge the latest changes. 'git pull origin main'"
 fi
 
-# Be flexible about whitespace and anchor at start of line.
-version_line=$(grep -E '^[[:space:]]*version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || true)
+version_line=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || true)
 if [[ -z "$version_line" ]]; then
     error "Could not find a semantic version in pyproject.toml."
 fi
-
-# Strip the key and the trailing quote, regardless of whitespace around '='
-current_version=${version_line#*[Vv]ersion*\"}
+current_version=${version_line#version = \"}
 current_version=${current_version%\"}
-
-# Validate and split safely; avoid silent exit under `set -e`
-if [[ ! "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    error "Parsed version '$current_version' is not MAJOR.MINOR.PATCH."
-fi
-
-# Use a guarded read so a mismatch can't kill the script silently
-if ! IFS='.' read -r major minor patch <<<"$current_version"; then
-    error "Failed to parse version components from '$current_version'."
-fi
+IFS='.' read -r major minor patch <<<"$current_version"
 
 case "$part" in
     major)
@@ -112,8 +105,6 @@ cleanup() {
     if ! $committed; then
         git checkout -- pyproject.toml >/dev/null 2>&1 || true
     fi
-    # Optional: surface unexpected failures
-    echo -e "${RED}Error:${RESET} Unexpected failure (see steps above)."
 }
 trap cleanup ERR INT
 

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -49,7 +49,7 @@ if ! git fetch origin main; then
 fi
 
 if ! git merge-base --is-ancestor origin/main HEAD; then
-    error "Current branch is not up to date with origin/main. Please rebase or merge the latest changes. `git pull origin main`"
+    error "Current branch is not up to date with origin/main. Please rebase or merge the latest changes. 'git pull origin main'"
 fi
 
 version_line=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || true)

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -49,7 +49,7 @@ if ! git fetch origin main; then
 fi
 
 if ! git merge-base --is-ancestor origin/main HEAD; then
-    error "Current branch is not up to date with origin/main. Please rebase or merge the latest changes."
+    error "Current branch is not up to date with origin/main. Please rebase or merge the latest changes. `git pull origin main`"
 fi
 
 version_line=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || true)

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -52,13 +52,25 @@ if ! git merge-base --is-ancestor origin/main HEAD; then
     error "Current branch is not up to date with origin/main. Please rebase or merge the latest changes. 'git pull origin main'"
 fi
 
-version_line=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || true)
+# Be flexible about whitespace and anchor at start of line.
+version_line=$(grep -E '^[[:space:]]*version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || true)
 if [[ -z "$version_line" ]]; then
     error "Could not find a semantic version in pyproject.toml."
 fi
-current_version=${version_line#version = \"}
+
+# Strip the key and the trailing quote, regardless of whitespace around '='
+current_version=${version_line#*[Vv]ersion*\"}
 current_version=${current_version%\"}
-IFS='.' read -r major minor patch <<<"$current_version"
+
+# Validate and split safely; avoid silent exit under `set -e`
+if [[ ! "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    error "Parsed version '$current_version' is not MAJOR.MINOR.PATCH."
+fi
+
+# Use a guarded read so a mismatch can't kill the script silently
+if ! IFS='.' read -r major minor patch <<<"$current_version"; then
+    error "Failed to parse version components from '$current_version'."
+fi
 
 case "$part" in
     major)

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -128,19 +128,19 @@ else
     error "Version number was not updated."
 fi
 
-# git commit -m "${current_version} -> ${next_version}"
-# committed=true
+git commit -m "${current_version} -> ${next_version}"
+committed=true
 
-# if ! git push; then
-#     error "Failed to push commit to upstream."
-# fi
+if ! git push; then
+    error "Failed to push commit to upstream."
+fi
 
-# if ! git tag "${tag_name}"; then
-#     error "Failed to create tag ${tag_name}."
-# fi
+if ! git tag "${tag_name}"; then
+    error "Failed to create tag ${tag_name}."
+fi
 
-# if ! git push origin "${tag_name}"; then
-#     error "Failed to push tag ${tag_name} to origin."
-# fi
+if ! git push origin "${tag_name}"; then
+    error "Failed to push tag ${tag_name} to origin."
+fi
 
 echo -e "${GREEN}Version bumped from ${current_version} to ${next_version}.${RESET}"

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -105,20 +105,18 @@ trap cleanup ERR INT
 
 if ! NEXT_VERSION="$next_version" python - <<'PY'
 from pathlib import Path
-import re
-import os
+import os, re
 
 path = Path("pyproject.toml")
 text = path.read_text()
-pattern = re.compile(r'^(version = ")([0-9]+\.[0-9]+\.[0-9]+)("$)', re.MULTILINE)
 
+pattern = re.compile(r'^(version\s*=\s*")(\d+\.\d+\.\d+)(")$', re.MULTILINE)
 next_version = os.environ["NEXT_VERSION"]
 
 if not pattern.search(text):
     raise SystemExit(1)
 
-updated, count = pattern.subn(rf'\1{next_version}\3', text, count=1)
-
+updated, count = pattern.subn(r'\g<1>' + next_version + r'\g<3>', text, count=1)
 if count != 1:
     raise SystemExit(1)
 

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -112,6 +112,8 @@ cleanup() {
     if ! $committed; then
         git checkout -- pyproject.toml >/dev/null 2>&1 || true
     fi
+    # Optional: surface unexpected failures
+    echo -e "${RED}Error:${RESET} Unexpected failure (see steps above)."
 }
 trap cleanup ERR INT
 

--- a/.github/bump_version.sh
+++ b/.github/bump_version.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED="\033[31m"
+GREEN="\033[32m"
+RESET="\033[0m"
+
+error() {
+    echo -e "${RED}Error:${RESET} $1" >&2
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    error "Usage: $0 {major|minor|patch}"
+fi
+
+part=$1
+case "$part" in
+    major|minor|patch)
+    ;;
+    
+    *)
+        error "Invalid argument '$part'. Expected one of: major, minor, patch."
+    ;;
+esac
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    error "This script must be run inside a git repository."
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if [[ -n $(git status --porcelain) ]]; then
+    error "Working tree must be clean before bumping the version."
+fi
+
+if ! git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
+    error "Current branch does not track a remote branch. Set an upstream with 'git push -u'."
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$current_branch" == "HEAD" ]]; then
+    error "Detached HEAD state is not supported. Checkout a branch before bumping the version."
+fi
+
+if ! git fetch origin main; then
+    error "Failed to fetch origin/main."
+fi
+
+if ! git merge-base --is-ancestor origin/main HEAD; then
+    error "Current branch is not up to date with origin/main. Please rebase or merge the latest changes."
+fi
+
+version_line=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml || true)
+if [[ -z "$version_line" ]]; then
+    error "Could not find a semantic version in pyproject.toml."
+fi
+current_version=${version_line#version = "}
+current_version=${current_version%"}
+IFS='.' read -r major minor patch <<<"$current_version"
+
+case "$part" in
+    major)
+        ((major++))
+        minor=0
+        patch=0
+        ;;
+    minor)
+        ((minor++))
+        patch=0
+        ;;
+    patch)
+        ((patch++))
+        ;;
+esac
+
+next_version="${major}.${minor}.${patch}"
+
+if [[ "$current_version" == "$next_version" ]]; then
+    error "Next version is identical to current version."
+fi
+
+tag_name="v${next_version}"
+
+if git show-ref --tags --verify --quiet "refs/tags/${tag_name}"; then
+    error "Tag ${tag_name} already exists locally."
+fi
+
+if ! remote_tag_output=$(git ls-remote --tags origin "refs/tags/${tag_name}"); then
+    error "Failed to query tags from origin."
+fi
+
+if [[ -n "$remote_tag_output" ]]; then
+    error "Tag ${tag_name} already exists on origin."
+fi
+
+committed=false
+cleanup() {
+    if ! $committed; then
+        git checkout -- pyproject.toml >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup ERR INT
+
+if ! NEXT_VERSION="$next_version" python - <<'PY'
+from pathlib import Path
+import re
+import os
+
+path = Path("pyproject.toml")
+text = path.read_text()
+pattern = re.compile(r'^(version = ")([0-9]+\.[0-9]+\.[0-9]+)("$)', re.MULTILINE)
+
+next_version = os.environ["NEXT_VERSION"]
+
+if not pattern.search(text):
+    raise SystemExit(1)
+
+updated, count = pattern.subn(rf'\1{next_version}\3', text, count=1)
+
+if count != 1:
+    raise SystemExit(1)
+
+path.write_text(updated)
+PY
+then
+    error "Failed to update version string in pyproject.toml."
+fi
+
+if ! git diff --quiet -- pyproject.toml; then
+    git add pyproject.toml
+else
+    error "Version number was not updated."
+fi
+
+# git commit -m "${current_version} -> ${next_version}"
+# committed=true
+
+# if ! git push; then
+#     error "Failed to push commit to upstream."
+# fi
+
+# if ! git tag "${tag_name}"; then
+#     error "Failed to create tag ${tag_name}."
+# fi
+
+# if ! git push origin "${tag_name}"; then
+#     error "Failed to push tag ${tag_name} to origin."
+# fi
+
+echo -e "${GREEN}Version bumped from ${current_version} to ${next_version}.${RESET}"

--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,3 @@ quick_test.ipynb
 # requirements are for the github workflow, people should use the pyproject.toml
 requirements.txt
 requirements-dev.txt
-
-# TODO: remove from .gitignore
-*bump_version.sh

--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ quick_test.ipynb
 # requirements are for the github workflow, people should use the pyproject.toml
 requirements.txt
 requirements-dev.txt
+
+# TODO: remove from .gitignore
+.github/bump_version.sh

--- a/.gitignore
+++ b/.gitignore
@@ -188,4 +188,4 @@ requirements.txt
 requirements-dev.txt
 
 # TODO: remove from .gitignore
-.github/bump_version.sh
+*bump_version.sh

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ help:
 	@echo "docs            : shortcut to build and serve generated documentation locally."
 	@echo "codecov         : check coverage of all the code."
 	@echo "clean           : cleans all unecessary files."
+	@echo "bump-version    : bump the project version. Usage: make bump-version PART={major,minor,patch}"
 
 #* UV
 uv-download:
@@ -123,6 +124,14 @@ build-remove:
 
 .PHONY: clean
 clean: pycache-remove build-remove # docker-remove
+
+.PHONY: bump-version
+bump-version:
+	@if [[ -z "$(PART)" ]]; then \
+		echo "PART is required. Usage: make bump-version PART={major,minor,patch}"; \
+		exit 1; \
+	fi
+	@.github/bump_version.sh $(PART)
 
 # If you are a coding agent reading this file, like codex or cursor
 # To run tests, you first need to install the dependencies


### PR DESCRIPTION
## Description

Increasing the version was a pain. Hence, this PR adds a script to automate it.

It is not only an automation, but a guide that prevents many mistakes we could make while doing it manually, like ensuring the current commit is up to date with main. It has many error-catching, and helping messages with the needed commands.

When to use it:
- You have a PR ready to be merged
- You want to increase the version and merge the PR

How to use it:
- go to the branch corresponding to the PR
- `make bump-version PART=major` (1.2.3 -> 2.0.0)
- `make bump-version PART=minor` (1.2.3 -> 1.3.0)
- `make bump-version PART=patch` (1.2.3 -> 1.2.4)

What it does:
- many preliminary checks (main branch can be fast-forwarded to commit)
- modify `pyproject.toml` `version x.x.x`
- commit with current to next versions (which triggers the pre-commit checks: linting and fast tests)
- push to origin
- create tag
- push tag (which releases the new version to pypi)

What it does not do:
- check the PR passes the CI
- check the PR is approved and no comments are
- merge the PR into main

## Type of Change

- 🚀 New feature (non-breaking change which adds functionality)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
