### PR TITLE
Making the jacobian calculation sequential

### DIFF
--- a/interpreto/model_wrapping/inference_wrapper.py
+++ b/interpreto/model_wrapping/inference_wrapper.py
@@ -271,7 +271,11 @@ class InferenceWrapper(ABC):
                 f"Consider adjust the batch size or the wrapper of split your data.",
             )
         # Check sequence length
-        if input_ids is not None and getattr(self.model.config, "max_position_embeddings", False) and input_ids.shape[-1] > self.model.config.max_position_embeddings:
+        if (
+            input_ids is not None
+            and getattr(self.model.config, "max_position_embeddings", False)
+            and input_ids.shape[-1] > self.model.config.max_position_embeddings
+        ):
             raise ValueError(
                 f"Input sequence length ({input_ids.shape[1]}) exceeds model's maximum "
                 f"input length ({self.model.config.max_position_embeddings}). Please truncate your inputs by specifying 'truncation=True' or 'max_length={self.model.config.max_position_embeddings}' to the tokenizer call or change the model."
@@ -638,24 +642,52 @@ class InferenceWrapper(ABC):
         model_inputs = self.embed(model_inputs)
         inputs_embeds = model_inputs["inputs_embeds"]
 
-        def get_score(inputs_embeds: torch.Tensor):
+        def get_score(inputs_embeds: torch.Tensor, attention_mask, targets):
             return self.get_targeted_logits(
-                {"inputs_embeds": inputs_embeds, "attention_mask": model_inputs["attention_mask"]}, targets
+                {
+                    "inputs_embeds": inputs_embeds,
+                    "attention_mask": attention_mask,
+                },
+                targets,
             )
 
         # Compute gradient of the selected logits:
-        grad_matrix = torch.autograd.functional.jacobian(get_score, inputs_embeds)  # (n, lt, n, l, d)
+        grad_matrices = []
+        for i, input_embeds in enumerate(inputs_embeds):
+            attention_mask = model_inputs["attention_mask"][i].unsqueeze(0)
+            if len(targets.shape) == 2 and targets.shape[0] > 1:
+                current_targets = targets[i].unsqueeze(0)
+            else:
+                current_targets = targets
 
-        grad_matrix = grad_matrix[
-            torch.arange(grad_matrix.shape[0]), :, torch.arange(grad_matrix.shape[0])
-        ]  # (n, lt, l, d)
+            grad_matrix_ = torch.autograd.functional.jacobian(
+                lambda x, attention_mask=attention_mask, current_targets=current_targets: get_score(
+                    x, attention_mask, current_targets
+                ),
+                input_embeds.unsqueeze(0),
+            )  # (1, lt, 1, l, d)
+            grad_matrices.append(grad_matrix_)
+
+        grad_matrix_cat = torch.cat(grad_matrices)
+        grad_matrix = grad_matrix_cat.squeeze()
+
         if input_x_gradient:
             grad_matrix = grad_matrix * inputs_embeds.unsqueeze(1)
 
         grad_matrix = grad_matrix.abs().mean(
             dim=-1
         )  # (n, lt, l)  # average over the embedding dimension  # TODO: discuss if th average should be forced or an argument
-        return grad_matrix
+
+        if len(grad_matrix.shape) == 3:
+            return grad_matrix
+        else:
+            batch_size = inputs_embeds.shape[0]
+            target_size = 1
+            if len(targets.shape) == 1:
+                target_size = targets.shape[0]
+            elif len(targets.shape) == 2:
+                target_size = targets.shape[1]
+            return grad_matrix.view((batch_size, target_size, -1))
 
     @get_gradients.register(Iterable)  # type: ignore
     def _get_gradients_from_iterable(


### PR DESCRIPTION
## Description

It's just a draft to make the jacobian calculation sequential.
It would require additional effort to make this optional.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
#96 

## Type of Change

- 🥂 Improvement (non-breaking change which improves an existing feature)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
