### PR TITLE
Solving dtype issue

### DIFF
--- a/interpreto/attributions/aggregations/base.py
+++ b/interpreto/attributions/aggregations/base.py
@@ -36,10 +36,26 @@ from jaxtyping import Float, jaxtyped
 from torch import Tensor
 
 
+def cast_input_to_dtype(func):
+    """
+    Ensure mask and results are on the device specified in the aggregator
+    """
+
+    def wrapper(self, results: torch.Tensor, mask, *args, **kwargs) -> Callable:
+        # TODO : eventually add device alignment as well
+        if mask is not None and mask.dtype != self.dtype:
+            mask = mask.to(self.dtype)
+        return func(self, results.to(self.dtype), mask)
+
+    return wrapper
+
+
 class Aggregator:
     """
     Abstract class for aggregation made at the end of attribution methods
     """
+
+    dtype: torch.dtype = torch.float32
 
     def aggregate(self, results: torch.Tensor, mask) -> torch.Tensor:
         """
@@ -110,6 +126,7 @@ class MaskwiseMeanAggregator(Aggregator):
     element.
     """
 
+    @cast_input_to_dtype
     @jaxtyped(typechecker=beartype)
     def aggregate(
         self,
@@ -128,6 +145,7 @@ class OcclusionAggregator(Aggregator):
     perturbation weighted by the corresponding mask.
     """
 
+    @cast_input_to_dtype
     @jaxtyped(typechecker=beartype)
     def aggregate(
         self,

--- a/interpreto/attributions/aggregations/linear_regression_aggregation.py
+++ b/interpreto/attributions/aggregations/linear_regression_aggregation.py
@@ -37,7 +37,7 @@ from jaxtyping import Float, jaxtyped
 from torch import Tensor
 from torch.nn import functional as F
 
-from interpreto.attributions.aggregations.base import Aggregator
+from interpreto.attributions.aggregations.base import Aggregator, cast_input_to_dtype
 
 DistancesFromMaskProtocol = Callable[[Float[Tensor, "p l"]], Float[Tensor, "p"]]
 SimilarityKernelProtocol = Callable[[Float[Tensor, "p"], float], Float[Tensor, "p"]]
@@ -127,6 +127,7 @@ class LinearRegressionAggregator(Aggregator):
         self.similarity_kernel = similarity_kernel
         self.kernel_width = kernel_width if kernel_width is not None else default_kernel_width_fn
 
+    @cast_input_to_dtype
     @jaxtyped(typechecker=beartype)
     def aggregate(
         self,
@@ -178,13 +179,15 @@ class LinearRegressionAggregator(Aggregator):
 
         # Compute closed form solution for the linear model
         # Add a constant column for the bias term
-        X: Float[Tensor, p, l + 1] = torch.cat([torch.ones(results.shape[0], 1, device=mask.device), mask], dim=1)
+        X: Float[Tensor, p, l + 1] = torch.cat(
+            [torch.ones(results.shape[0], 1, device=mask.device, dtype=self.dtype), mask], dim=1
+        )
 
         # formula from wikipedia: https://en.wikipedia.org/wiki/Weighted_least_squares
         # \theta =(X^T w X)^{-1} (X^T w y)
         XT_W: Float[Tensor, l + 1, p] = X.T * weights
         epsilon: Float[Tensor, l + 1, l + 1] = (
-            torch.eye(XT_W.shape[0], device=XT_W.device) * 1e-6
+            torch.eye(XT_W.shape[0], device=XT_W.device, dtype=self.dtype) * 1e-6
         )  # To prevent inversion errors
         theta: Float[Tensor, l + 1, t] = torch.inverse(XT_W @ X + epsilon) @ (XT_W @ results)
 

--- a/interpreto/model_wrapping/inference_wrapper.py
+++ b/interpreto/model_wrapping/inference_wrapper.py
@@ -33,7 +33,7 @@ processing. The class is designed to be subclassed for specific model types and 
 from __future__ import annotations
 
 import warnings
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from collections.abc import Callable, Generator, Iterable, MutableMapping
 from enum import Enum
 from functools import singledispatchmethod
@@ -187,16 +187,16 @@ class InferenceWrapper(ABC):
         Args:
             device (torch.device): wanted device (e.g., "cpu" or "cuda").
         """
-        self.model.to(device)  # type: ignore
+        self.model.to(device)
 
-    def to(self, device: torch.device):
+    def to(self, device: torch.device, dtype: torch.dtype | None = None):
         """
         Move the model to the specified device.
 
         Args:
             device (torch.device): The device to which the model should be moved.
         """
-        self.device = device
+        self.model.to(device=device, dtype=dtype)
 
     def cpu(self):
         """
@@ -209,6 +209,14 @@ class InferenceWrapper(ABC):
         Move the model to the GPU.
         """
         self.device = torch.device("cuda")
+
+    @property
+    def dtype(self):
+        return self.model.dtype
+
+    @dtype.setter
+    def dtype(self, dtype: torch.dtype):
+        self.model.to(dtype=dtype)
 
     def embed(self, model_inputs: TensorMapping) -> TensorMapping:
         """
@@ -229,7 +237,7 @@ class InferenceWrapper(ABC):
         # If input ids are present, get the embeddings and add them to the model inputs
         if "input_ids" in model_inputs:
             base_shape = model_inputs["input_ids"].shape
-            input_ids = model_inputs["input_ids"].flatten(0, -2).to(self.device)
+            input_ids = model_inputs["input_ids"].flatten(0, -2).to(self.device, self.dtype)
             flatten_embeds = self.model.get_input_embeddings()(input_ids)
             model_inputs["inputs_embeds"] = flatten_embeds.view(*base_shape, flatten_embeds.shape[-1])
             return model_inputs
@@ -279,11 +287,11 @@ class InferenceWrapper(ABC):
 
         # send input to device
         if input_ids is not None:
-            input_ids = input_ids.to(self.device)
+            input_ids = input_ids.to(self.device, self.dtype)
         if inputs_embeds is not None:
-            inputs_embeds = inputs_embeds.to(self.device)
+            inputs_embeds = inputs_embeds.to(self.device, self.dtype)
         if attention_mask is not None:
-            attention_mask = attention_mask.to(self.device)
+            attention_mask = attention_mask.to(self.device, self.dtype)
 
         # Call wrapped model
         if inputs_embeds is not None:

--- a/interpreto/model_wrapping/inference_wrapper.py
+++ b/interpreto/model_wrapping/inference_wrapper.py
@@ -33,7 +33,7 @@ processing. The class is designed to be subclassed for specific model types and 
 from __future__ import annotations
 
 import warnings
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Iterable, MutableMapping
 from enum import Enum
 from functools import singledispatchmethod
@@ -162,7 +162,9 @@ class InferenceWrapper(ABC):
         if device is None:
             device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-        self.model.to(device)  # type: ignore
+        if not (getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)):
+            self.model.to(device)  # type: ignore
+
         self.batch_size = batch_size
 
         assert callable(mode), "mode should be a callable function from `InferenceModes`"
@@ -237,7 +239,7 @@ class InferenceWrapper(ABC):
         # If input ids are present, get the embeddings and add them to the model inputs
         if "input_ids" in model_inputs:
             base_shape = model_inputs["input_ids"].shape
-            input_ids = model_inputs["input_ids"].flatten(0, -2).to(self.device, self.dtype)
+            input_ids = model_inputs["input_ids"].flatten(0, -2).to(self.device)
             flatten_embeds = self.model.get_input_embeddings()(input_ids)
             model_inputs["inputs_embeds"] = flatten_embeds.view(*base_shape, flatten_embeds.shape[-1])
             return model_inputs
@@ -279,7 +281,11 @@ class InferenceWrapper(ABC):
                 f"Consider adjust the batch size or the wrapper of split your data.",
             )
         # Check sequence length
-        if input_ids is not None and getattr(self.model.config, "max_position_embeddings", False) and input_ids.shape[-1] > self.model.config.max_position_embeddings:
+        if (
+            input_ids is not None
+            and getattr(self.model.config, "max_position_embeddings", False)
+            and input_ids.shape[-1] > self.model.config.max_position_embeddings
+        ):
             raise ValueError(
                 f"Input sequence length ({input_ids.shape[1]}) exceeds model's maximum "
                 f"input length ({self.model.config.max_position_embeddings}). Please truncate your inputs by specifying 'truncation=True' or 'max_length={self.model.config.max_position_embeddings}' to the tokenizer call or change the model."
@@ -287,11 +293,11 @@ class InferenceWrapper(ABC):
 
         # send input to device
         if input_ids is not None:
-            input_ids = input_ids.to(self.device, self.dtype)
+            input_ids = input_ids.to(self.device)
         if inputs_embeds is not None:
             inputs_embeds = inputs_embeds.to(self.device, self.dtype)
         if attention_mask is not None:
-            attention_mask = attention_mask.to(self.device, self.dtype)
+            attention_mask = attention_mask.to(self.device)
 
         # Call wrapped model
         if inputs_embeds is not None:
@@ -299,7 +305,6 @@ class InferenceWrapper(ABC):
                 return self.model(inputs_embeds=inputs_embeds, attention_mask=attention_mask)
             except NotImplementedError as e:
                 raise IncompatibilityError from e
-
         return self.model(input_ids=input_ids, attention_mask=attention_mask)
 
     @overload

--- a/tests/concepts/metrics/test_consim.py
+++ b/tests/concepts/metrics/test_consim.py
@@ -587,7 +587,9 @@ def test_consim_predictions_accuracy():
     # empty predictions or different lengths should return None
     assert ConSim._predictions_accuracy([], ["a", "b"]) is None, "empty predictions should return None"
     assert ConSim._predictions_accuracy(["a", "b"], []) is None, "empty predictions should return None"
-    assert ConSim._predictions_accuracy(["a"], ["a", "b"]) is None, "different prediction and llm responses should return None"
+    assert ConSim._predictions_accuracy(["a"], ["a", "b"]) is None, (
+        "different prediction and llm responses should return None"
+    )
 
 
 def test_consim_compute_score(splitted_encoder_ml: ModelWithSplitPoints):

--- a/tests/model_wrapping/test_classification_inference_wrapper.py
+++ b/tests/model_wrapping/test_classification_inference_wrapper.py
@@ -73,6 +73,30 @@ def test_classification_inference_wrapper_multiple_sentences(bert_model, bert_to
     assert torch.all(torch.isclose(target_logits, test_target_logits, atol=1e-5))
 
 
+def test_classification_inference_wrapper_with_quantized_models(bert_model, bert_tokenizer, sentences, quantization):
+    # Model preparation
+    quantized_model = quantization(bert_model)
+    inference_wrapper = ClassificationInferenceWrapper(quantized_model, batch_size=5, device=DEVICE)
+    inference_wrapper.pad_token_id = bert_tokenizer.pad_token_id
+
+    # Reference values
+    tokens = bert_tokenizer(sentences, return_tensors="pt", padding=True, truncation=True)
+    tokens.to(DEVICE)
+    logits = bert_model(**tokens).logits
+    targets = logits.argmax(dim=-1)
+    predefined_targets = torch.randperm(logits.shape[-1]).to(DEVICE)
+    target_logits = torch.gather(logits, dim=-1, index=predefined_targets.unsqueeze(0).expand(logits.shape[0], -1))
+
+    # Tests
+    test_logits = torch.stack(list(inference_wrapper.get_logits(tokens.copy())))
+    test_targets = torch.stack(list(inference_wrapper.get_targets(tokens.copy())))
+    test_target_logits = torch.stack(list(inference_wrapper.get_targeted_logits(tokens.copy(), predefined_targets)))
+
+    assert torch.all(torch.isclose(logits, test_logits, atol=1e-5))
+    assert torch.all(torch.isclose(targets, test_targets, atol=1e-5))
+    assert torch.all(torch.isclose(target_logits, test_target_logits, atol=1e-5))
+
+
 if __name__ == "__main__":
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
 

--- a/tests/model_wrapping/test_inference_wrapper.py
+++ b/tests/model_wrapping/test_inference_wrapper.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.utils.quantization_config import BitsAndBytesConfig
+
+from interpreto.model_wrapping.generation_inference_wrapper import GenerationInferenceWrapper
+
+# Define quantization configurations
+BAB_CONFIGS = [
+    BitsAndBytesConfig(load_in_8bit=True),
+    BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type="nf4", bnb_4bit_compute_type=torch.float16),
+    BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type="fp4", bnb_4bit_compute_type=torch.float16),
+    BitsAndBytesConfig(load_in_8bit=True, llm_int8_threshold=6.0),
+    BitsAndBytesConfig(load_in_8bit=True, llm_int8_skip_modules=["lm_head", "output"]),
+]
+
+# Define models to test
+MODELS = [
+    "hf-internal-testing/tiny-random-gpt2",
+    "hf-internal-testing/tiny-random-LlamaForCausalLM",
+    "hf-internal-testing/tiny-random-MistralForCausalLM",
+]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+@pytest.mark.parametrize("bab_config", BAB_CONFIGS)
+def test_inference_wrapper_with_quantized_models(model_name, bab_config):
+    """
+    Test the GenerationInferenceWrapper with quantized HuggingFace models.
+    """
+    # Load the quantized model
+    quantized_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=bab_config)
+
+    # Wrap the model
+    wrapped_model = GenerationInferenceWrapper(quantized_model)
+
+    # Prepare dummy input
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+
+    # Perform inference
+    outputs = wrapped_model.get_logits({"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)})
+
+    # Assertions
+    assert outputs is not None
+    assert isinstance(outputs, torch.Tensor)
+    assert outputs.shape[0] == input_ids.shape[0]  # Ensure batch size matches


### PR DESCRIPTION
## Description

Add better dtype management in the inference wrapper
"to" method of the wrapper now follows torch-like signature and more general behaviour :
`my_inference_wrapper.to(device=some_device, dtype=some_dtype)`

If embeddings are passed directly to the inference wrapper, they will be casted to the adapted type (allows dealing with quantized models)

Also add light dtype management for aggregators

## Related Issue

Solves #101

## Type of Change

<!-- Keep only the ones that apply -->

- 🔧 Bug fix (non-breaking change which fixes an issue)
- 🥂 Improvement (non-breaking change which improves an existing feature)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
