### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,7 @@ jobs:
     - name: Install dependencies
       run: |
         source .venv/bin/activate
-        make update-deps
-        uv pip install -r requirements-dev.txt
+        uv pip install ".[docs,lint,notebook]"
 
 
     - name: Export HF_HUB_TOKEN

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,8 @@ repos:
         exclude: LICENSE
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    # Keep this revision aligned with the pyproject Ruff pin.
+    rev: v0.16.4
     hooks:
       - id: ruff-format
       - id: ruff

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include LICENSE
-include requirements.txt
 include *.md
 include *.py
 include *.yaml

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ help:
 	@echo "uv-download     : downloads and installs the uv package manager"
 	@echo "install         : installs required dependencies"
 	@echo "install-dev     : installs the dev dependencies for the project"
-	@echo "update-deps     : updates the dependencies and writes them to requirements.txt"
 	@echo "fix-style       : run checks on files and potentially modifies them."
 	@echo "check-style     : run checks on files without modifying them."
 	@echo "lint            : run linting on all files"
@@ -50,16 +49,10 @@ install:
 
 .PHONY: install-dev
 install-dev:
-	make uv-activate && make update-deps && uv pip install -r requirements-dev.txt && pre-commit install && pre-commit autoupdate && uv pip install -e .
-
-.PHONY: update-deps
-update-deps:
-	uv pip compile pyproject.toml -o requirements.txt
-	uv pip compile --all-extras pyproject.toml -o requirements-dev.txt
-
-.PHONY: install-ci
-install-ci:
-	make uv-activate && make update-deps && uv pip install -r requirements-dev.txt
+	if [ ! -f .venv/bin/python ]; then uv venv; fi && \
+		source .venv/bin/activate && \
+		uv pip install -e ".[docs,lint,notebook]" && \
+		pre-commit install
 
 #* Linting
 .PHONY: fix-style

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ codecov:
 	$(PYTHON) -m pytest -n auto --cov interpreto --cov-report html
 
 #* Docs
+build-docs serve-docs deploy-docs: export DISABLE_MKDOCS_2_WARNING := true
+build-docs serve-docs deploy-docs: export NO_MKDOCS_2_WARNING := 1
+
 .PHONY: build-docs
 build-docs:
 	make uv-activate && mkdocs build

--- a/Makefile
+++ b/Makefile
@@ -103,18 +103,18 @@ build-docs serve-docs deploy-docs: export NO_MKDOCS_2_WARNING := 1
 
 .PHONY: build-docs
 build-docs:
-	make uv-activate && mkdocs build
+	uv run --extra docs mkdocs build
 
 .PHONY: serve-docs
 serve-docs:
-	make uv-activate && mkdocs serve
+	uv run --extra docs mkdocs serve
 
 .PHONY: deploy-docs
 deploy-docs:
-	make uv-activate && mkdocs gh-deploy
+	uv run --extra docs mkdocs gh-deploy
 
 .PHONY: docs
-docs: build-docs serve-docs
+docs: serve-docs
 
 #* Cleaning
 .PHONY: pycache-remove

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The library is available on PyPI, try `pip install interpreto` to install it.
 
 Checkout the tutorials to get started:
 
-- [Attributions walkthrough](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/attribution_walkthrough.ipynb) (both classification and generation)
+- [Attributions walkthrough](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/attribution_tutorial.ipynb) (both classification and generation)
 - [Classification concept-based explanations](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/classification_concept_tutorial.ipynb)
 - [Generation concept-based explanations](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/generation_concept_tutorial.ipynb)
 
@@ -40,7 +40,7 @@ They all work seamlessly for both classification (`...ForSequenceClassification`
 
 **Inference-based Methods:**
 
-- [`KernelShap`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/kernel_shap/) — [Lundberg and Lee, 2017](https://arxiv.org/abs/1705.07874)
+- [`KernelShap`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/kernelshap/) — [Lundberg and Lee, 2017](https://arxiv.org/abs/1705.07874)
 - [`LIME`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/lime/) — [Ribeiro et al., 2013](https://dl.acm.org/doi/abs/10.1145/2939672.2939778)
 - [`Occlusion`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/occlusion/) — [Zeiler and Fergus, 2014](https://link.springer.com/chapter/10.1007/978-3-319-10590-1_53)
 - [`Sobol`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/sobol/) — [Fel et al., 2021](https://proceedings.neurips.cc/paper/2021/hash/da94cbeff56cfda50785df477941308b-Abstract.html)
@@ -48,12 +48,12 @@ They all work seamlessly for both classification (`...ForSequenceClassification`
 **Gradient-based methods:**
 
 - [`GradientShap`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/gradient_shap/) — [Lundberg and Lee, 2017](https://arxiv.org/abs/1705.07874)
-- [`InputxGradient`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/inputx_gradient/) — [Simonyan et al., 2013](https://arxiv.org/abs/1312.6034)
-- [`Integrated Gradient`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/integrated_gradient/) — [Sundararajan et al., 2017](http://proceedings.mlr.press/v70/sundararajan17a.html)
+- `InputxGradient` — [Simonyan et al., 2013](https://arxiv.org/abs/1312.6034)
+- [`Integrated Gradient`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/integrated_gradients/) — [Sundararajan et al., 2017](http://proceedings.mlr.press/v70/sundararajan17a.html)
 - [`Saliency`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/saliency/) — [Simonyan et al., 2013](https://arxiv.org/abs/1312.6034)
-- [`SmoothGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/smooth_grad/) — [Smilkov et al., 2017](https://arxiv.org/abs/1706.03825)
-- [`SquareGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/square_grad/) — [Hooker et al., 2019](https://arxiv.org/abs/1806.10758)
-- [`VarGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/var_grad/) — [Richter et al., 2020](https://proceedings.neurips.cc/paper/2020/hash/9c22c0b51b3202246463e986c7e205df-Abstract.html)
+- [`SmoothGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/smoothgrad/) — [Smilkov et al., 2017](https://arxiv.org/abs/1706.03825)
+- [`SquareGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/squaregrad/) — [Hooker et al., 2019](https://arxiv.org/abs/1806.10758)
+- [`VarGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/vargrad/) — [Richter et al., 2020](https://proceedings.neurips.cc/paper/2020/hash/9c22c0b51b3202246463e986c7e205df-Abstract.html)
 
 ### 💡 Concept-Based Methods or Mechanistic Interpretability
 
@@ -83,16 +83,16 @@ Both can be tuned with `bias_calibrator` and `normalization` parameters.
 
 **2. (unsupervised) Dictionary Learning for Concept Discovery** (mainly via [`overcomplete`](https://github.com/KempnerInstitute/overcomplete)):
 
-- Interpret neurons directly via [`NeuronsAsConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/neurons_as_concepts/)
-- [`NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.NMFConcepts), [`Semi-NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.SemiNMFConcepts), [`ConvexNMF`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.ConvexNMFConcepts)
-- [`ICA`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.ICAConcepts), [`SVD`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.SVDConcepts), [`PCA`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.PCAConcepts), [`KMeans`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.KMeansConcepts)
-- SAE variants: [`Vanilla SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.VanillaSAEConcepts), [`TopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.TopKSAEConcepts), [`JumpReLU SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.JumpReLUSAEConcepts), [`BatchTopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.BatchTopKSAEConcepts)
+- Interpret neurons directly via [`NeuronsAsConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/neurons_as_concepts/)
+- [`NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.NMFConcepts), [`Semi-NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.SemiNMFConcepts), [`ConvexNMF`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.ConvexNMFConcepts)
+- [`ICA`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.ICAConcepts), [`SVD`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.SVDConcepts), [`PCA`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.PCAConcepts), [`KMeans`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.KMeansConcepts)
+- SAE variants: [`Vanilla SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.VanillaSAEConcepts), [`TopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.TopKSAEConcepts), [`JumpReLU SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.JumpReLUSAEConcepts), [`BatchTopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.BatchTopKSAEConcepts)
 
 **3. (unsupervised) Available Concept Interpretation Techniques:**
 
-- Top-k tokens from tokenizer vocabulary via [`TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.TopKInputs) and `use_vocab=True`
-- Top-k tokens/words/sentences/samples from specific datasets via [`TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.TopKInputs)
-- Label concepts via LLMs with [`LLMLabels`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.LLMLabels) ([Bills et al. 2023](https://openai.com/index/language-models-can-explain-neurons-in-language-models/))
+- Top-k tokens from tokenizer vocabulary via [`TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/topk_inputs/#interpreto.concepts.interpretations.TopKInputs) and `use_vocab=True`
+- Top-k tokens/words/sentences/samples from specific datasets via [`TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/topk_inputs/#interpreto.concepts.interpretations.TopKInputs)
+- Label concepts via LLMs with [`LLMLabels`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/llm_labels/#interpreto.concepts.interpretations.LLMLabels) ([Bills et al. 2023](https://openai.com/index/language-models-can-explain-neurons-in-language-models/))
 - Input-to-concept attribution from dataset examples ([Concept Attributions](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/concept_attributions/)) ([Jourdan et al. 2023](https://aclanthology.org/2023.findings-acl.317/))
 
 <details><summary>Concept Interpretation Techniques Added in the future:</summary>
@@ -107,7 +107,7 @@ Both can be tuned with `bias_calibrator` and `normalization` parameters.
 
 Estimate the contribution of each concept to the model output.
 
-Can be obtained with any concept-based explainer via [`MethodConcepts.concept_output_gradient()`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/base/#interpreto.concepts.ConceptAutoEncoderExplainer.concept_output_gradient).
+Can be obtained with any concept-based explainer via [`MethodConcepts.concept_output_gradient()`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/base/#interpreto.concepts.ConceptAutoEncoderExplainer.concept_output_gradient).
 
 <details><summary><b>Papers available in the future:</b></summary>
 
@@ -136,7 +136,7 @@ Or independently:
 
 - Concept-space (dictionary learning evaluation)
   - faithfulness: [`MSE`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/reconstruction_metrics/#interpreto.concepts.metrics.MSE), [`FID`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/reconstruction_metrics/#interpreto.concepts.metrics.FID), and [`ReconstructionError`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/reconstruction_metrics/#interpreto.concepts.metrics.ReconstructionError)
-  - complexity: [`Sparsity`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/#interpreto.concepts.metrics.Sparsity), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity/), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity/#interpreto.concepts.metrics.SparsityRatio)
+  - complexity: [`Sparsity`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/#interpreto.concepts.metrics.Sparsity), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/#interpreto.concepts.metrics.SparsityRatio)
   - stability: [`Stability`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/dictionary_metrics/#interpreto.concepts.metrics.Stability)
 - Concepts interpretations
   - No metric yet, will be included soon.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-*This file contains a high-level description of changes that were merged into the main branch since the last release. Refer to the releases page for an exhaustive overview of changes introduced at each release.*

--- a/docs/api/concepts/interpretations/base.md
+++ b/docs/api/concepts/interpretations/base.md
@@ -1,0 +1,20 @@
+# Base Classes & Utilities
+
+The base interpretation class defines the shared interface for making concept
+dimensions interpretable. The `extract_ngrams` utility provides reusable
+preprocessing for text-based interpretations.
+
+## API Reference
+
+::: interpreto.concepts.interpretations.base.BaseConceptInterpretationMethod
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: true
+      inherited_members: true
+
+::: interpreto.concepts.interpretations.extract_ngrams
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: true

--- a/docs/api/concepts/interpretations/llm_labels.md
+++ b/docs/api/concepts/interpretations/llm_labels.md
@@ -26,9 +26,3 @@ based on the top-k activating inputs. This provides a human-readable summary of 
       inherited_members: true
       members:
         - generate
-
-::: interpreto.concepts.interpretations.extract_ngrams
-    handler: python
-    options:
-      show_root_heading: true
-      show_source: true

--- a/docs/api/concepts/interpretations/topk_inputs.md
+++ b/docs/api/concepts/interpretations/topk_inputs.md
@@ -33,9 +33,3 @@ topk_words = topk.interpret(inputs=dataset, concepts_indices="all")
       inherited_members: true
       members:
         - interpret
-
-::: interpreto.concepts.interpretations.extract_ngrams
-    handler: python
-    options:
-      show_root_heading: true
-      show_source: true

--- a/docs/api/concepts/metrics/overview.md
+++ b/docs/api/concepts/metrics/overview.md
@@ -4,7 +4,7 @@ icon: material/text-short
 
 # Concept Explanation Metrics
 
-As described in the [Concept Explainers](../overview/) page, concept-based explanations are obtain by applying several steps:
+As described in the [Concept Explainers](../overview.md) page, concept-based explanations are obtain by applying several steps:
 
 - Defining the concept-space, usually through dictionary learning.
 
@@ -78,18 +78,18 @@ Several properties of the concept-space are desirable:
 Concept-space faithfulness is often measured via the reconstruction error of the latent activations when projected back and forth in the concept space.
 Either in the latent space or in the logits space. The distance used to compare activations has a big impact on what is measured.
 
-In `interpreto` you can use the [ReconstructionError](../reconstruction_metrics/#custom) to define a custom metric by specifying a `reconstruction_space` and a `distance_function`.
-Or you can use the [MSE](../reconstruction_metrics/#mse) or [FID](../reconstruction_metrics/#fid) metrics.
+In `interpreto` you can use the [ReconstructionError](reconstruction_metrics.md#custom) to define a custom metric by specifying a `reconstruction_space` and a `distance_function`.
+Or you can use the [MSE](reconstruction_metrics.md#mse) or [FID](reconstruction_metrics.md#fid) metrics.
 
 ### Concept-space complexity
 
 The concept-space complexity is often measured via the sparsity of its activations.
 
-In `interpreto` you can use: [Sparsity](../sparsity_metrics/#sparsity) and [SparsityRatio](../sparsity_metrics/#sparsity-ratio).
+In `interpreto` you can use: [Sparsity](sparsity_metrics.md#sparsity) and [SparsityRatio](sparsity_metrics.md#sparsity-ratio).
 
 ### Concept-space stability
 
 The concept-space should stay the same across different training regimes.
 *i.e.* with different seeds, different data splits...
 
-In `interpreto` you can use: [Stability](../stability_metrics/#stability) to compare concept-model dictionaries.
+In `interpreto` you can use: [Stability](dictionary_metrics.md#stability) to compare concept-model dictionaries.

--- a/docs/api/concepts/overview.md
+++ b/docs/api/concepts/overview.md
@@ -2,7 +2,7 @@
 
 ## Tutorials
 
-- [Concept Explanations Examples](../../notebooks/concept_examples.ipynb)
+- [Concept Explanations Examples](../../notebooks/classification_concept_tutorial.ipynb)
 
 ## Common API
 
@@ -163,7 +163,7 @@ results = explainer.explain(inputs)
 > **Note:** Only perturbation-based methods (Occlusion, Lime, KernelShap, Sobol) are supported.
 > Gradient-based methods are not compatible with the input-to-concept pipeline.
 
-For classification models, use [`SplitterForClassification`](./splitter_for_classification.md)
+For classification models, use [`SplitterForClassification`](./splitters/splitter_for_classification.md)
 instead of `ModelWithSplitPoints` for a simpler setup.
 
 More details in the [Concept Attributions documentation](./interpretations/concept_attributions.md).

--- a/docs/api/concepts/overview.md
+++ b/docs/api/concepts/overview.md
@@ -16,11 +16,7 @@ from interpreto.concepts.interpretations import TopKInputs
 
 # 1. Load and split your model
 model_with_split_points = ModelWithSplitPoints(
-    "your_model_id",
-    split_point="your_split_point",
-    automodel="your_automodel",
-    nb_concepts=50,
-    device_map="cuda"
+    "your_model_id", split_point="your_split_point", automodel="your_automodel", nb_concepts=50, device_map="cuda"
 )
 
 # 2. Compute the model activations on the split_point

--- a/docs/api/concepts/probes.md
+++ b/docs/api/concepts/probes.md
@@ -66,7 +66,7 @@ model = ModelWithSplitPoints(
 activations, _ = model.get_activations(
     texts,
     activation_granularity=model.activation_granularities.SAMPLE,
-    aggregation_strategy=model.aggregation_strategies.MEAN, # MAX and LAST are also often compared in the literature
+    aggregation_strategy=model.aggregation_strategies.MEAN,  # MAX and LAST are also often compared in the literature
 )
 
 probe = CosineCentroidProbe()

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ The library is available on PyPI, try `pip install interpreto` to install it.
 
 Checkout the tutorials to get started:
 
-- [Attributions walkthrough](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/attribution_walkthrough.ipynb) (both classification and generation)
+- [Attributions walkthrough](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/attribution_tutorial.ipynb) (both classification and generation)
 - [Classification concept-based explanations](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/classification_concept_tutorial.ipynb)
 - [Generation concept-based explanations](https://github.com/FOR-sight-ai/interpreto/tree/main/docs/notebooks/generation_concept_tutorial.ipynb)
 
@@ -44,7 +44,7 @@ They all work seamlessly for both classification (`...ForSequenceClassification`
 
 **Inference-based Methods:**
 
-- [`KernelShap`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/kernel_shap/) — [Lundberg and Lee, 2017](https://arxiv.org/abs/1705.07874)
+- [`KernelShap`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/kernelshap/) — [Lundberg and Lee, 2017](https://arxiv.org/abs/1705.07874)
 - [`LIME`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/lime/) — [Ribeiro et al., 2013](https://dl.acm.org/doi/abs/10.1145/2939672.2939778)
 - [`Occlusion`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/occlusion/) — [Zeiler and Fergus, 2014](https://link.springer.com/chapter/10.1007/978-3-319-10590-1_53)
 - [`Sobol`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/sobol/) — [Fel et al., 2021](https://proceedings.neurips.cc/paper/2021/hash/da94cbeff56cfda50785df477941308b-Abstract.html)
@@ -52,12 +52,12 @@ They all work seamlessly for both classification (`...ForSequenceClassification`
 **Gradient-based methods:**
 
 - [`GradientShap`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/gradient_shap/) — [Lundberg and Lee, 2017](https://arxiv.org/abs/1705.07874)
-- [`InputxGradient`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/inputx_gradient/) — [Simonyan et al., 2013](https://arxiv.org/abs/1312.6034)
-- [`Integrated Gradient`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/integrated_gradient/) — [Sundararajan et al., 2017](http://proceedings.mlr.press/v70/sundararajan17a.html)
+- `InputxGradient` — [Simonyan et al., 2013](https://arxiv.org/abs/1312.6034)
+- [`Integrated Gradient`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/integrated_gradients/) — [Sundararajan et al., 2017](http://proceedings.mlr.press/v70/sundararajan17a.html)
 - [`Saliency`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/saliency/) — [Simonyan et al., 2013](https://arxiv.org/abs/1312.6034)
-- [`SmoothGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/smooth_grad/) — [Smilkov et al., 2017](https://arxiv.org/abs/1706.03825)
-- [`SquareGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/square_grad/) — [Hooker et al., 2019](https://arxiv.org/abs/1806.10758)
-- [`VarGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/var_grad/) — [Richter et al., 2020](https://proceedings.neurips.cc/paper/2020/hash/9c22c0b51b3202246463e986c7e205df-Abstract.html)
+- [`SmoothGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/smoothgrad/) — [Smilkov et al., 2017](https://arxiv.org/abs/1706.03825)
+- [`SquareGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/squaregrad/) — [Hooker et al., 2019](https://arxiv.org/abs/1806.10758)
+- [`VarGrad`](https://for-sight-ai.github.io/interpreto/api/attributions/methods/vargrad/) — [Richter et al., 2020](https://proceedings.neurips.cc/paper/2020/hash/9c22c0b51b3202246463e986c7e205df-Abstract.html)
 
 ### 💡 Concept-Based Methods or Mechanistic Interpretability
 
@@ -87,10 +87,10 @@ Both can be tuned with `bias_calibrator` and `normalization` parameters.
 
 **2. (unsupervised) Dictionary Learning for Concept Discovery** (mainly via [`overcomplete`](https://github.com/KempnerInstitute/overcomplete)):
 
-- Interpret neurons directly via [`NeuronsAsConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/neurons_as_concepts/)
-- [`NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.NMFConcepts), [`Semi-NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.SemiNMFConcepts), [`ConvexNMF`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.ConvexNMFConcepts)
-- [`ICA`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.ICAConcepts), [`SVD`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.SVDConcepts), [`PCA`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.PCAConcepts), [`KMeans`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.KMeansConcepts)
-- SAE variants: [`Vanilla SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.VanillaSAEConcepts), [`TopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.TopKSAEConcepts), [`JumpReLU SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.JumpReLUSAEConcepts), [`BatchTopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.BatchTopKSAEConcepts)
+- Interpret neurons directly via [`NeuronsAsConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/neurons_as_concepts/)
+- [`NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.NMFConcepts), [`Semi-NMF`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.SemiNMFConcepts), [`ConvexNMF`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.ConvexNMFConcepts)
+- [`ICA`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.ICAConcepts), [`SVD`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.SVDConcepts), [`PCA`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.PCAConcepts), [`KMeans`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.KMeansConcepts)
+- SAE variants: [`Vanilla SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.VanillaSAEConcepts), [`TopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.TopKSAEConcepts), [`JumpReLU SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.JumpReLUSAEConcepts), [`BatchTopK SAE`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.BatchTopKSAEConcepts)
 
 **3. (unsupervised) Available Concept Interpretation Techniques:**
 
@@ -138,7 +138,7 @@ Or independently:
 
 - Concept-space (dictionary learning evaluation)
   - faithfulness: [`MSE`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/reconstruction_metrics/#interpreto.concepts.metrics.MSE), [`FID`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/reconstruction_metrics/#interpreto.concepts.metrics.FID), and [`ReconstructionError`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/reconstruction_metrics/#interpreto.concepts.metrics.ReconstructionError)
-  - complexity: [`Sparsity`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/#interpreto.concepts.metrics.Sparsity), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity/), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity/#interpreto.concepts.metrics.SparsityRatio)
+  - complexity: [`Sparsity`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/#interpreto.concepts.metrics.Sparsity), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/), [`SparsityRatio`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/sparsity_metrics/#interpreto.concepts.metrics.SparsityRatio)
   - stability: [`Stability`](https://for-sight-ai.github.io/interpreto/api/concepts/metrics/dictionary_metrics/#interpreto.concepts.metrics.Stability)
 - Concepts interpretations
   - No metric yet, will be included soon.
@@ -147,7 +147,7 @@ Or independently:
 
 ## 👍 Contributing
 
-Feel free to propose your ideas or come and contribute with us on the Interpreto 🪄 toolbox! We have a specific document where we describe in a simple way how to make your [first pull request](docs/contributing.md).
+Feel free to propose your ideas or come and contribute with us on the Interpreto 🪄 toolbox! We have a specific document where we describe in a simple way how to make your [first pull request](contributing.md).
 
 ## 👀 See Also
 
@@ -184,4 +184,4 @@ If you use Interpreto 🪄 as part of your workflow in a scientific publication,
 
 ## 📝 License
 
-The package is released under [MIT license](LICENSE).
+The package is released under [MIT license](https://github.com/FOR-sight-ai/interpreto/blob/main/LICENSE).

--- a/docs/notebooks/classification_concept_tutorial.ipynb
+++ b/docs/notebooks/classification_concept_tutorial.ipynb
@@ -48,11 +48,11 @@
     "\n",
     "We choose a `DistilBERT` fine-tuned on the `AG-News` dataset and split it just before the classification head.\n",
     "\n",
-    "To split the model, we use the [`interpreto.SplitSequenceClassification`](https://for-sight-ai.github.io/interpreto/api/concepts/splitter_for_classification/) which wraps around the `transformers` model.\n",
+    "To split the model, we use the [`interpreto.SplitSequenceClassification`](https://for-sight-ai.github.io/interpreto/api/concepts/splitters/splitter_for_classification/) which wraps around the `transformers` model.\n",
     "\n",
     "It splits the model at the [CLS] token, thus the first part is the encoder and the second the classification head. Which is the setup we highly recommend for interpretability.\n",
     "\n",
-    "For other settings, we invite the user to use the [`interpreto.ModelWithSplitPoints`](https://for-sight-ai.github.io/interpreto/api/concepts/model_with_split_points/) instead (parent of the above class)."
+    "For other settings, we invite the user to use the [`interpreto.ModelWithSplitPoints`](https://for-sight-ai.github.io/interpreto/api/concepts/splitters/model_with_split_points/) instead (parent of the above class)."
    ]
   },
   {
@@ -80,7 +80,7 @@
     "\n",
     "Then we extract the activations of the [CLS] token of each document.\n",
     "\n",
-    "[`interpreto.SplitSequenceClassification.get_activations()`](https://for-sight-ai.github.io/interpreto/api/concepts/split_sequence_classification/#interpreto.SplitSequenceClassification.get_activations)"
+    "`interpreto.SplitSequenceClassification.get_activations()`"
    ]
   },
   {
@@ -139,7 +139,7 @@
     "\n",
     "The `concept_model` is an attribute of our concept explainer, similarly to the `model_with_split_points`. With these these two elements, we can go from inputs to concepts and from concepts to outputs.\n",
     "\n",
-    "In this tutorial, we use [`interpreto.concepts.ICAConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.ICAConcepts) built upon the ICA (Independent Component Analysis) dimension reduction algorithm.\n",
+    "In this tutorial, we use [`interpreto.concepts.ICAConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.ICAConcepts) built upon the ICA (Independent Component Analysis) dimension reduction algorithm.\n",
     "\n",
     "There are at least 15 others concept model available in interpreto. do not hesitate to explore them.\n",
     "\n",
@@ -173,7 +173,7 @@
     "\n",
     "We have our concepts and the link between concepts and classes. But now, we need to make sense of these concepts.\n",
     "\n",
-    "In this case, we will use the [`interpreto.concepts.interpretations.TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.TopKInputs) to find the 8 words which activates the most our concepts."
+    "In this case, we will use the [`interpreto.concepts.interpretations.TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/topk_inputs/#interpreto.concepts.interpretations.TopKInputs) to find the 8 words which activates the most our concepts."
    ]
   },
   {
@@ -223,11 +223,11 @@
     "\n",
     "It is the same when you train a model on tabular data, not all features are used.\n",
     "\n",
-    "In this step, we use the [`ConceptAutoEncoderExplainer.concept_output_gradients`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/base/#interpreto.concepts.ConceptAutoEncoderExplainer.concept_output_gradient) to evaluate the importance of each concept with respect to the predicted classes.\n",
+    "In this step, we use the [`ConceptAutoEncoderExplainer.concept_output_gradients`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/base/#interpreto.concepts.ConceptAutoEncoderExplainer.concept_output_gradient) to evaluate the importance of each concept with respect to the predicted classes.\n",
     "\n",
     "> ➡️ **Note**\n",
     ">\n",
-    "> All unsupervised concept-based explainers in Interpreto inherit from [`ConceptAutoEncoderExplainer`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/base/#interpreto.concepts.ConceptAutoEncoderExplainer).\n",
+    "> All unsupervised concept-based explainers in Interpreto inherit from [`ConceptAutoEncoderExplainer`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/base/#interpreto.concepts.ConceptAutoEncoderExplainer).\n",
     "\n",
     "> ➡️ **Note 2**\n",
     ">\n",
@@ -2910,9 +2910,9 @@
     ">\n",
     "> - Improve the interpretation of concepts:\n",
     ">   - Play with the parameters\n",
-    ">   - Try [`LLMLabels`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.LLMLabels) see [next section](#class-wise)\n",
+    ">   - Try [`LLMLabels`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/llm_labels/#interpreto.concepts.interpretations.LLMLabels) see [next section](#class-wise)\n",
     ">\n",
-    "> - Try to evaluate the concepts, to automatically find the best methods. Check this other tutorial: [TODO](TODO)\n",
+    "> - Try to evaluate the concepts to automatically find the best methods.\n",
     ">\n",
     "> - Never forget the **faithfulness-plausibility trade-off** of explanations"
    ]
@@ -2926,8 +2926,8 @@
     "This section aims at improving the concepts learned by the model. We try three different approaches:\n",
     "\n",
     "- Training class-wise concepts\n",
-    "- Using another concept model: [`SemiNMFConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.SemiNMFConcepts)\n",
-    "- Using [`interpreto.concepts.LLMLabels`](https://for-sight-ai.github.io/interpreto/) to interpret the concepts\n",
+    "- Using another concept model: [`SemiNMFConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.SemiNMFConcepts)\n",
+    "- Using [`interpreto.concepts.LLMLabels`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/llm_labels/#interpreto.concepts.interpretations.LLMLabels) to interpret the concepts\n",
     "\n",
     "When a single concept-space is defined for all classes, concepts tend to correspond to the classes themselves. In particular, when the concept-space is built upon on the latent space just before the classification head.\n",
     "\n",

--- a/docs/notebooks/examples/classification_ngram_concept_tutorial.ipynb
+++ b/docs/notebooks/examples/classification_ngram_concept_tutorial.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "We choose a `bert` fine-tuned on the `go-emotions` dataset and split it just before the classification head.\n",
     "\n",
-    "To split the model, we use the [`interpreto.ModelWithSplitPoints`](https://for-sight-ai.github.io/interpreto/api/concepts/model_with_split_points/) which wraps around the `transformers` model and allows the computation of activations at the specified `split_point`."
+    "To split the model, we use the [`interpreto.ModelWithSplitPoints`](https://for-sight-ai.github.io/interpreto/api/concepts/splitters/model_with_split_points/) which wraps around the `transformers` model and allows the computation of activations at the specified `split_point`."
    ]
   },
   {
@@ -147,7 +147,7 @@
     ">\n",
     "> In this notebook, many things are specific to the use of the [CLS] token.\n",
     "\n",
-    "[`interpreto.ModelWithSplitPoints.get_activations()`](https://for-sight-ai.github.io/interpreto/api/concepts/model_with_split_points/#interpreto.ModelWithSplitPoints.get_activations)"
+    "[`interpreto.ModelWithSplitPoints.get_activations()`](https://for-sight-ai.github.io/interpreto/api/concepts/splitters/model_with_split_points/#interpreto.ModelWithSplitPoints.get_activations)"
    ]
   },
   {
@@ -239,7 +239,7 @@
     "\n",
     "The `concept_model` is an attribute of our concept explainer, similarly to the `model_with_split_points`. With these these two elements, we can go from inputs to concepts and from concepts to outputs.\n",
     "\n",
-    "In this tutorial, we use [`interpreto.concepts.SemiNMFConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/optim/#interpreto.concepts.SemiNMFConcepts). There are at least 15 others concept model available in interpreto. do not hesitate to explore them."
+    "In this tutorial, we use [`interpreto.concepts.SemiNMFConcepts`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/optim/#interpreto.concepts.SemiNMFConcepts). There are at least 15 others concept model available in interpreto. do not hesitate to explore them."
    ]
   },
   {
@@ -265,7 +265,7 @@
    "source": [
     "## 4. 🏷️ **Interpret** the concept dimensions <a class=\"anchor\" id=\"interpret\"></a>\n",
     "\n",
-    "We need to make sense of these concepts. In this case, we will use the [`interpreto.concepts.interpretations.TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.TopKInputs) to find the k (here, 5) ngram words (here 6 grams) which activates the most our concepts.\n",
+    "We need to make sense of these concepts. In this case, we will use the [`interpreto.concepts.interpretations.TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/topk_inputs/#interpreto.concepts.interpretations.TopKInputs) to find the k (here, 5) ngram words (here 6 grams) which activates the most our concepts.\n",
     "\n",
     "The `unique_words_kwargs` parameter controls how n-grams are extracted from the dataset before being passed to the model:\n",
     "\n",

--- a/docs/notebooks/generation_concept_tutorial.ipynb
+++ b/docs/notebooks/generation_concept_tutorial.ipynb
@@ -213,7 +213,7 @@
     "\n",
     "Now we can fit a concept model on the activations. They exist more or less complex concept models. Here we use an SAE, so it is quite complex and has a lot more parameters than a simple concept model.\n",
     "\n",
-    "In particular, we use [`interpreto.concepts.BatchTopK`](https://for-sight-ai.github.io/interpreto/api/concepts/methods/sae/#interpreto.concepts.methods.BatchTopKConcepts).\n",
+    "In particular, we use [`interpreto.concepts.BatchTopK`](https://for-sight-ai.github.io/interpreto/api/concepts/concept_spaces/sae/#interpreto.concepts.methods.BatchTopKSAEConcepts).\n",
     "\n",
     "The `concept_explainer` wraps around both `splitter`, the model wrapper, and the `concept_model`.\n",
     "\n",
@@ -285,7 +285,7 @@
    "source": [
     "### 4.1 Interpret concepts via top-k tokens\n",
     "\n",
-    "Via [`interpreto.concepts.TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.TopKInputs), it is possible to extract the top-k tokens that activate each concept the most."
+    "Via [`interpreto.concepts.TopKInputs`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/topk_inputs/#interpreto.concepts.interpretations.TopKInputs), it is possible to extract the top-k tokens that activate each concept the most."
    ]
   },
   {
@@ -351,7 +351,7 @@
    "source": [
     "### 4.2 Interpret concepts with an LLM labels\n",
     "\n",
-    "Here we use [`interpreto.concepts.LLMLabels`](https://for-sight-ai.github.io/interpreto/api/concepts/concepts_interpretations/#interpreto.concepts.interpretations.LLMLabels), it uses LLM to label the concepts based on examples activating the concept."
+    "Here we use [`interpreto.concepts.LLMLabels`](https://for-sight-ai.github.io/interpreto/api/concepts/interpretations/llm_labels/#interpreto.concepts.interpretations.LLMLabels), it uses LLM to label the concepts based on examples activating the concept."
    ]
   },
   {
@@ -3315,7 +3315,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 6.2 💭 Evaluate the concepts-interpretations from the [fourth step](#important)"
+    "### 6.2 💭 Evaluate the concepts-interpretations from the [fourth step](#interpret)"
    ]
   },
   {

--- a/docs/notebooks/generation_probe_tutorial.ipynb
+++ b/docs/notebooks/generation_probe_tutorial.ipynb
@@ -60,7 +60,7 @@
                 "\n",
                 "We use **Qwen3-0.6B**, a small but capable language model. We split it at a late layer (layer 20 out of 28) — truthfulness representations tend to emerge in later layers.\n",
                 "\n",
-                "We use [`ModelWithSplitPoints`](https://for-sight-ai.github.io/interpreto/api/concepts/model_with_split_points/) to wrap the model and enable activation extraction.\n",
+                "We use [`ModelWithSplitPoints`](https://for-sight-ai.github.io/interpreto/api/concepts/splitters/model_with_split_points/) to wrap the model and enable activation extraction.\n",
                 "\n",
                 "> ➡️ **Note**\n",
                 ">\n",

--- a/interpreto/attributions/aggregations/linear_regression_aggregation.py
+++ b/interpreto/attributions/aggregations/linear_regression_aggregation.py
@@ -157,6 +157,10 @@ class LinearRegressionAggregator(Aggregator):
                 + f"Got {results.shape} perturbations and {results.shape} results."
             )
 
+        # There are no features to regress when the mask has zero width.
+        if l == 0:
+            return results.new_empty((t, 0))
+
         # Define the weights for the linear model
         if self.distance_function is not None:  # LIME
             # Compute distance between perturbations and original input using the mask

--- a/interpreto/attributions/methods/kernel_shap.py
+++ b/interpreto/attributions/methods/kernel_shap.py
@@ -95,9 +95,6 @@ class KernelShap(MultitaskExplainerMixin, AttributionExplainer):
             inference_mode (Callable[[torch.Tensor], torch.Tensor], optional): The mode used for inference.
                 It can be either one of LOGITS, SOFTMAX, or LOG_SOFTMAX. Use InferenceModes to choose the appropriate mode.
             n_perturbations (int): the number of perturbations to generate
-            distance_function (DistancesFromMaskProtocol): distance function used to compute weights of perturbed samples in the linear model training.
-            similarity_kernel (SimilarityKernelProtocol): similarity kernel used to compute weights of perturbed samples in the linear model training.
-            kernel_width (float | Callable): kernel width used in the `similarity_kernel`
             device (torch.device): device on which the attribution method will be run
         """
         replace_token_id = setup_token_ids(model, tokenizer)

--- a/interpreto/attributions/methods/sobol_attribution.py
+++ b/interpreto/attributions/methods/sobol_attribution.py
@@ -102,7 +102,7 @@ class Sobol(MultitaskExplainerMixin, AttributionExplainer):
             inference_mode (Callable[[torch.Tensor], torch.Tensor], optional): The mode used for inference.
                 It can be either one of LOGITS, SOFTMAX, or LOG_SOFTMAX. Use InferenceModes to choose the appropriate mode.
             n_token_perturbations (int): the number of perturbations to generate
-            sobol_indices (SobolIndicesOrders): Sobol indices order, either `FIRST_ORDER` or `TOTAL_ORDER`.
+            sobol_indices_order (SobolIndicesOrders): Sobol indices order, either `FIRST_ORDER` or `TOTAL_ORDER`.
             sampler (SequenceSamplers): Sobol sequence sampler, either `SOBOL`, `HALTON` or `LatinHypercube`.
             device (torch.device): device on which the attribution method will be run
         """

--- a/interpreto/attributions/metrics/insertion_deletion.py
+++ b/interpreto/attributions/metrics/insertion_deletion.py
@@ -517,7 +517,6 @@ class Insertion(MultitaskMetricMixin, InsertionDeletionBase):
         model (PreTrainedModel): model used to generate explanations
         tokenizer (PreTrainedTokenizer): Hugging Face tokenizer associated with the model
         batch_size (int): batch size for the inference of the metric
-        granularity (Granularity): granularity level of the perturbations (token, word, sentence, etc.)
         device (torch.device): device on which the attribution method will be run
         n_perturbations (int): number of perturbations from which the metric will be computed (i.e. the number of
             steps from which the AUC will be computed).
@@ -577,7 +576,6 @@ class Deletion(MultitaskMetricMixin, InsertionDeletionBase):
         model (PreTrainedModel): model used to generate explanations
         tokenizer (PreTrainedTokenizer): Hugging Face tokenizer associated with the model
         batch_size (int): batch size for the inference of the metric
-        granularity (Granularity): granularity level of the perturbations (token, word, sentence, etc.)
         device (torch.device): device on which the attribution method will be run
         n_perturbations (int): number of perturbations from which the metric will be computed (i.e. the number of
             steps from which the AUC will be computed).

--- a/interpreto/attributions/perturbations/shap_perturbation.py
+++ b/interpreto/attributions/perturbations/shap_perturbation.py
@@ -94,6 +94,9 @@ class ShapTokenPerturbator(IdsPerturbator):
         # Simplify typing
         p, l = self.n_perturbations, mask_dim
 
+        if l < 1:
+            return torch.zeros((p, l), dtype=torch.float)
+
         # If the requested number of perturbations is greater than the possible number of perturbations
         # we set it to the maximum possible number of perturbations
         # This solves the issue 68, which arise when l = 2 and p at least greater than 30

--- a/interpreto/concepts/base.py
+++ b/interpreto/concepts/base.py
@@ -161,7 +161,7 @@ class ConceptEncoderExplainer(ABC, Generic[ConceptModel]):
         encoding step using the `concept_model` to convert activations to latent concepts.
 
     Attributes:
-        splitter (BaseSplitter): The model to apply the explanation on.
+        splitter (interpreto.concepts.splitters.BaseSplitter): The model to apply the explanation on.
             The split point is determined by the model's `split_point` attribute.
         concept_model (ConceptModelProtocol): The model used to extract concepts from the activations of
             `splitter`. The only assumption for classes inheriting from this class is that
@@ -181,7 +181,7 @@ class ConceptEncoderExplainer(ABC, Generic[ConceptModel]):
         """Initializes the concept explainer with a given splitted model.
 
         Args:
-            splitter (BaseSplitter): The model to apply the explanation on.
+            splitter (interpreto.concepts.splitters.BaseSplitter): The model to apply the explanation on.
                 Its `split_point` attribute determines where activations are extracted.
             concept_model (ConceptModelProtocol): The model used to extract concepts from
                 the activations of `splitter`.
@@ -298,7 +298,7 @@ class ConceptAutoEncoderExplainer(ConceptEncoderExplainer[BaseDictionaryLearning
     Attributes:
         splitter (ModelWithSplitPoints): The model to apply the explanation on.
             The split point is determined by the model's `split_point` attribute.
-        concept_model ([BaseDictionaryLearning](https://github.com/KempnerInstitute/overcomplete/blob/24568ba5736cbefca4b78a12246d92a1be04a1f4/overcomplete/base.py#L10)): The model used to extract concepts from the
+        concept_model (BaseDictionaryLearning): The model used to extract concepts from the
             activations of  `splitter`. The only assumption for classes inheriting from this class is
             that the `concept_model` can encode activations into concepts with `activations_to_concepts`.
         is_fitted (bool): Whether the `concept_model` was fit on model activations.
@@ -316,9 +316,9 @@ class ConceptAutoEncoderExplainer(ConceptEncoderExplainer[BaseDictionaryLearning
         """Initializes the concept explainer with a given splitted model.
 
         Args:
-            splitter (BaseSplitter): The model to apply the explanation on.
+            splitter (interpreto.concepts.splitters.BaseSplitter): The model to apply the explanation on.
                 Its `split_point` attribute determines where activations are extracted.
-            concept_model ([BaseDictionaryLearning](https://github.com/KempnerInstitute/overcomplete/blob/24568ba5736cbefca4b78a12246d92a1be04a1f4/overcomplete/base.py#L10)): The model used to extract concepts from
+            concept_model (BaseDictionaryLearning): The model used to extract concepts from
                 the activations of `splitter`.
         """
         self.concept_model: BaseDictionaryLearning

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -351,6 +351,7 @@ class BaseConceptInterpretationMethod(ABC):
                 inputs,
                 activation_granularity=self.activation_granularity,
                 aggregation_strategy=self.aggregation_strategy,
+                forward_kwargs={"truncation": True},
             )
             return self.concepts_activations_from_source(latent_activations=latent_activations, inputs=inputs)
 
@@ -384,6 +385,7 @@ class BaseConceptInterpretationMethod(ABC):
             latent_activations, _ = self.concept_explainer.splitter.get_activations(
                 input_ids,
                 activation_granularity=ActivationGranularity.ALL_TOKENS,
+                forward_kwargs={"truncation": True},
             )
         else:
             # we need to add the CLS token and maybe the EOS token to the ids
@@ -411,6 +413,7 @@ class BaseConceptInterpretationMethod(ABC):
             latent_activations, _ = self.concept_explainer.splitter.get_activations(
                 repeated_template_ids,
                 activation_granularity=self.activation_granularity,
+                forward_kwargs={"truncation": True},
             )
 
         # compute the vocabulary's concepts activations

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -45,7 +45,9 @@ from nltk.tokenize import word_tokenize
 from interpreto.commons.granularity import GranularityAggregationStrategy
 from interpreto.concepts.base import ConceptEncoderExplainer
 from interpreto.concepts.splitters.model_with_split_points import ActivationGranularity
-from interpreto.concepts.splitters.splitter_for_classification import SplitterForClassification
+from interpreto.concepts.splitters.splitter_for_classification import (
+    SplitterForClassification,
+)
 from interpreto.typing import ConceptsActivations, LatentActivations
 
 
@@ -138,7 +140,9 @@ def extract_ngrams(
 
         for size in range(2, n + 1):  # skips size 1 as covered over
             for i in range(len(processed) - size + 1):
-                tuple_ngram_counts[tuple(processed[i : i + size])] += 1  # >1-gram tuples
+                tuple_ngram_counts[tuple(processed[i : i + size])] += (
+                    1  # >1-gram tuples
+                )
 
     str_ngram_counts: Counter[str] = Counter(
         {
@@ -162,10 +166,17 @@ def verify_concepts_indices(
     if isinstance(concepts_indices, int):
         concepts_indices = [concepts_indices]
 
-    if not isinstance(concepts_indices, list) or not all(isinstance(c, int) for c in concepts_indices):
-        raise ValueError(f"`concepts_indices` should be 'all', an int, or a list of int. Received {concepts_indices}.")
+    if not isinstance(concepts_indices, list) or not all(
+        isinstance(c, int) for c in concepts_indices
+    ):
+        raise ValueError(
+            f"`concepts_indices` should be 'all', an int, or a list of int. Received {concepts_indices}."
+        )
 
-    if max(concepts_indices) >= concepts_activations.shape[1] or min(concepts_indices) < 0:
+    if (
+        max(concepts_indices) >= concepts_activations.shape[1]
+        or min(concepts_indices) < 0
+    ):
         raise ValueError(
             f"At least one concept index out of bounds. `max(concepts_indices)`: {max(concepts_indices)} >= {concepts_activations.shape[1]}."
         )
@@ -180,13 +191,17 @@ def verify_granular_inputs(
     concepts_activations: ConceptsActivations | None = None,
 ):
     if len(granular_inputs) != len(sure_concepts_activations):
-        if latent_activations is not None and len(granular_inputs) != len(latent_activations):
+        if latent_activations is not None and len(granular_inputs) != len(
+            latent_activations
+        ):
             raise ValueError(
                 f"The lengths of the granulated inputs do not match the number of provided latent activations {len(granular_inputs)} != {len(latent_activations)}"
                 "If you provide latent activations, make sure they have the same granularity as the inputs."
                 "This might happen if you use `use_vocab=True` and `use_unique_words=True` and provide `latent_activations`."
             )
-        if concepts_activations is not None and len(granular_inputs) != len(concepts_activations):
+        if concepts_activations is not None and len(granular_inputs) != len(
+            concepts_activations
+        ):
             raise ValueError(
                 f"The lengths of the granulated inputs do not match the number of provided concepts activations {len(granular_inputs)} != {len(concepts_activations)}"
                 "If you provide concepts activations, make sure they have the same granularity as the inputs."
@@ -264,7 +279,9 @@ class BaseConceptInterpretationMethod(ABC):
             )
 
         if use_unique_words and use_vocab:
-            raise ValueError("Cannot use both `use_unique_words` and `use_vocab`. Please use only one of them.")
+            raise ValueError(
+                "Cannot use both `use_unique_words` and `use_vocab`. Please use only one of them."
+            )
 
         self.concept_explainer: ConceptEncoderExplainer = concept_explainer
         self.activation_granularity: ActivationGranularity = activation_granularity
@@ -337,11 +354,17 @@ class BaseConceptInterpretationMethod(ABC):
             # batch over latent activations for concept encoding
             concepts_activations_list = []
             with torch.no_grad():
-                for batch_idx in range(0, latent_activations.shape[0], self.concept_encoding_batch_size):
+                for batch_idx in range(
+                    0, latent_activations.shape[0], self.concept_encoding_batch_size
+                ):
                     # concept model forward pass
-                    batch_concepts_activations = self.concept_explainer.activations_to_concepts(
-                        latent_activations[batch_idx : batch_idx + self.concept_encoding_batch_size]
-                    ).cpu()
+                    batch_concepts_activations = (
+                        self.concept_explainer.activations_to_concepts(
+                            latent_activations[
+                                batch_idx : batch_idx + self.concept_encoding_batch_size
+                            ]
+                        ).cpu()
+                    )
                     concepts_activations_list.append(batch_concepts_activations)
             concepts_activations = torch.cat(concepts_activations_list, dim=0)
             return concepts_activations
@@ -353,7 +376,9 @@ class BaseConceptInterpretationMethod(ABC):
                 aggregation_strategy=self.aggregation_strategy,
                 forward_kwargs={"truncation": True},
             )
-            return self.concepts_activations_from_source(latent_activations=latent_activations, inputs=inputs)
+            return self.concepts_activations_from_source(
+                latent_activations=latent_activations, inputs=inputs
+            )
 
         raise ValueError(
             "No source provided. Please provide either `inputs`, `latent_activations`, or `concepts_activations`."
@@ -372,12 +397,16 @@ class BaseConceptInterpretationMethod(ABC):
                 - The concept activations for each token
         """
         # extract and sort the vocabulary
-        vocab_dict: dict[str, int] = self.concept_explainer.splitter.tokenizer.get_vocab()
+        vocab_dict: dict[str, int] = (
+            self.concept_explainer.splitter.tokenizer.get_vocab()
+        )
         inputs, input_ids = zip(*vocab_dict.items(), strict=True)  # type: ignore
         inputs: list[str] = list(inputs)  # type: ignore
 
         # unsqueeze for all ids to be considered as a single sample
-        input_ids: Float[torch.Tensor, "v 1"] = torch.tensor(list(input_ids)).unsqueeze(1)
+        input_ids: Float[torch.Tensor, "v 1"] = torch.tensor(list(input_ids)).unsqueeze(
+            1
+        )
         vocab_size = input_ids.shape[0]
 
         if self.activation_granularity != ActivationGranularity.CLS_TOKEN:
@@ -392,7 +421,9 @@ class BaseConceptInterpretationMethod(ABC):
             # so that we can get correct CLS activations
 
             # first step extract the template
-            template_ids = self.concept_explainer.splitter.tokenizer("a", return_tensors="pt")["input_ids"]
+            template_ids = self.concept_explainer.splitter.tokenizer(
+                "a", return_tensors="pt"
+            )["input_ids"]
 
             # if we are not in a template [CLS] a [EOS]
             if len(template_ids) != 3:  # type: ignore
@@ -418,7 +449,9 @@ class BaseConceptInterpretationMethod(ABC):
 
         # compute the vocabulary's concepts activations
         with torch.no_grad():
-            concepts_activations = self.concept_explainer.activations_to_concepts(latent_activations)
+            concepts_activations = self.concept_explainer.activations_to_concepts(
+                latent_activations
+            )
         return inputs, concepts_activations
 
     @jaxtyped(typechecker=beartype)
@@ -453,7 +486,8 @@ class BaseConceptInterpretationMethod(ABC):
         if self.activation_granularity == ActivationGranularity.TOKEN:
             # we can use the tokenizer to split the inputs into tokens
             granular_texts: list[list[str]] = [
-                self.concept_explainer.splitter.tokenizer.tokenize(text) for text in inputs
+                self.concept_explainer.splitter.tokenizer.tokenize(text)
+                for text in inputs
             ]
         else:
             # Get granular texts from the inputs
@@ -464,14 +498,20 @@ class BaseConceptInterpretationMethod(ABC):
                 truncation=True,
                 return_offsets_mapping=True,
             )
-            granular_texts: list[list[str]] = self.activation_granularity.value.get_decomposition(  # type: ignore  (sure list[list[str]] with return_text=True)
-                tokens,
-                tokenizer=self.concept_explainer.splitter.tokenizer,
-                return_text=True,
+            granular_texts: list[list[str]] = (
+                self.activation_granularity.value.get_decomposition(  # type: ignore  (sure list[list[str]] with return_text=True)
+                    tokens,
+                    tokenizer=self.concept_explainer.splitter.tokenizer,
+                    return_text=True,
+                )
             )
 
-        granular_flattened_texts = [text for sample_texts in granular_texts for text in sample_texts]
-        granular_flattened_sample_id = [i for i, sample_texts in enumerate(granular_texts) for _ in sample_texts]
+        granular_flattened_texts = [
+            text for sample_texts in granular_texts for text in sample_texts
+        ]
+        granular_flattened_sample_id = [
+            i for i, sample_texts in enumerate(granular_texts) for _ in sample_texts
+        ]
         return granular_flattened_texts, granular_flattened_sample_id
 
     def get_granular_inputs_and_concept_activations(
@@ -518,7 +558,9 @@ class BaseConceptInterpretationMethod(ABC):
 
         """
         if concepts_indices == "all":
-            concepts_indices = list(range(self.concept_explainer.concept_model.nb_concepts))
+            concepts_indices = list(
+                range(self.concept_explainer.concept_model.nb_concepts)
+            )
 
         # compute the concepts activations from the provided source, can also create inputs from the vocabulary
         if self.use_vocab:
@@ -526,7 +568,9 @@ class BaseConceptInterpretationMethod(ABC):
             # Case 1: use_vocab=True
             granular_inputs: list[str]
             sure_concepts_activations: Float[torch.Tensor, "nl cpt"]
-            granular_inputs, sure_concepts_activations = self.concepts_activations_from_vocab()
+            granular_inputs, sure_concepts_activations = (
+                self.concepts_activations_from_vocab()
+            )
 
             granular_sample_ids: list[int] = list(range(len(granular_inputs)))
         else:
@@ -537,7 +581,10 @@ class BaseConceptInterpretationMethod(ABC):
                 # ----------------------------------------------------------------------------------
                 # Case 2: use_unique_words >= 1
                 # first list unique words/ngrams from the inputs and compute the activations from them
-                if self.activation_granularity != ActivationGranularity.CLS_TOKEN:
+                if self.activation_granularity not in [
+                    ActivationGranularity.CLS_TOKEN,
+                    ActivationGranularity.SAMPLE,
+                ]:
                     raise ValueError(
                         f"`use_unique_words` requires `activation_granularity=CLS_TOKEN`, "
                         f"got `{self.activation_granularity}`. "
@@ -545,7 +592,10 @@ class BaseConceptInterpretationMethod(ABC):
                         "to represent each ngram as a single unit."
                     )
                 granular_inputs: list[str] = extract_ngrams(
-                    inputs=inputs, n=self.use_unique_words, return_counts=False, **self.unique_words_kwargs
+                    inputs=inputs,
+                    n=self.use_unique_words,
+                    return_counts=False,
+                    **self.unique_words_kwargs,
                 )  # type: ignore  (sure list[str] with return_counts=False)
                 if latent_activations is not None and concepts_activations is not None:
                     warnings.warn(

--- a/interpreto/concepts/interpretations/base.py
+++ b/interpreto/concepts/interpretations/base.py
@@ -140,9 +140,7 @@ def extract_ngrams(
 
         for size in range(2, n + 1):  # skips size 1 as covered over
             for i in range(len(processed) - size + 1):
-                tuple_ngram_counts[tuple(processed[i : i + size])] += (
-                    1  # >1-gram tuples
-                )
+                tuple_ngram_counts[tuple(processed[i : i + size])] += 1  # >1-gram tuples
 
     str_ngram_counts: Counter[str] = Counter(
         {
@@ -166,17 +164,10 @@ def verify_concepts_indices(
     if isinstance(concepts_indices, int):
         concepts_indices = [concepts_indices]
 
-    if not isinstance(concepts_indices, list) or not all(
-        isinstance(c, int) for c in concepts_indices
-    ):
-        raise ValueError(
-            f"`concepts_indices` should be 'all', an int, or a list of int. Received {concepts_indices}."
-        )
+    if not isinstance(concepts_indices, list) or not all(isinstance(c, int) for c in concepts_indices):
+        raise ValueError(f"`concepts_indices` should be 'all', an int, or a list of int. Received {concepts_indices}.")
 
-    if (
-        max(concepts_indices) >= concepts_activations.shape[1]
-        or min(concepts_indices) < 0
-    ):
+    if max(concepts_indices) >= concepts_activations.shape[1] or min(concepts_indices) < 0:
         raise ValueError(
             f"At least one concept index out of bounds. `max(concepts_indices)`: {max(concepts_indices)} >= {concepts_activations.shape[1]}."
         )
@@ -191,17 +182,13 @@ def verify_granular_inputs(
     concepts_activations: ConceptsActivations | None = None,
 ):
     if len(granular_inputs) != len(sure_concepts_activations):
-        if latent_activations is not None and len(granular_inputs) != len(
-            latent_activations
-        ):
+        if latent_activations is not None and len(granular_inputs) != len(latent_activations):
             raise ValueError(
                 f"The lengths of the granulated inputs do not match the number of provided latent activations {len(granular_inputs)} != {len(latent_activations)}"
                 "If you provide latent activations, make sure they have the same granularity as the inputs."
                 "This might happen if you use `use_vocab=True` and `use_unique_words=True` and provide `latent_activations`."
             )
-        if concepts_activations is not None and len(granular_inputs) != len(
-            concepts_activations
-        ):
+        if concepts_activations is not None and len(granular_inputs) != len(concepts_activations):
             raise ValueError(
                 f"The lengths of the granulated inputs do not match the number of provided concepts activations {len(granular_inputs)} != {len(concepts_activations)}"
                 "If you provide concepts activations, make sure they have the same granularity as the inputs."
@@ -279,9 +266,7 @@ class BaseConceptInterpretationMethod(ABC):
             )
 
         if use_unique_words and use_vocab:
-            raise ValueError(
-                "Cannot use both `use_unique_words` and `use_vocab`. Please use only one of them."
-            )
+            raise ValueError("Cannot use both `use_unique_words` and `use_vocab`. Please use only one of them.")
 
         self.concept_explainer: ConceptEncoderExplainer = concept_explainer
         self.activation_granularity: ActivationGranularity = activation_granularity
@@ -354,17 +339,11 @@ class BaseConceptInterpretationMethod(ABC):
             # batch over latent activations for concept encoding
             concepts_activations_list = []
             with torch.no_grad():
-                for batch_idx in range(
-                    0, latent_activations.shape[0], self.concept_encoding_batch_size
-                ):
+                for batch_idx in range(0, latent_activations.shape[0], self.concept_encoding_batch_size):
                     # concept model forward pass
-                    batch_concepts_activations = (
-                        self.concept_explainer.activations_to_concepts(
-                            latent_activations[
-                                batch_idx : batch_idx + self.concept_encoding_batch_size
-                            ]
-                        ).cpu()
-                    )
+                    batch_concepts_activations = self.concept_explainer.activations_to_concepts(
+                        latent_activations[batch_idx : batch_idx + self.concept_encoding_batch_size]
+                    ).cpu()
                     concepts_activations_list.append(batch_concepts_activations)
             concepts_activations = torch.cat(concepts_activations_list, dim=0)
             return concepts_activations
@@ -376,9 +355,7 @@ class BaseConceptInterpretationMethod(ABC):
                 aggregation_strategy=self.aggregation_strategy,
                 forward_kwargs={"truncation": True},
             )
-            return self.concepts_activations_from_source(
-                latent_activations=latent_activations, inputs=inputs
-            )
+            return self.concepts_activations_from_source(latent_activations=latent_activations, inputs=inputs)
 
         raise ValueError(
             "No source provided. Please provide either `inputs`, `latent_activations`, or `concepts_activations`."
@@ -397,16 +374,12 @@ class BaseConceptInterpretationMethod(ABC):
                 - The concept activations for each token
         """
         # extract and sort the vocabulary
-        vocab_dict: dict[str, int] = (
-            self.concept_explainer.splitter.tokenizer.get_vocab()
-        )
+        vocab_dict: dict[str, int] = self.concept_explainer.splitter.tokenizer.get_vocab()
         inputs, input_ids = zip(*vocab_dict.items(), strict=True)  # type: ignore
         inputs: list[str] = list(inputs)  # type: ignore
 
         # unsqueeze for all ids to be considered as a single sample
-        input_ids: Float[torch.Tensor, "v 1"] = torch.tensor(list(input_ids)).unsqueeze(
-            1
-        )
+        input_ids: Float[torch.Tensor, "v 1"] = torch.tensor(list(input_ids)).unsqueeze(1)
         vocab_size = input_ids.shape[0]
 
         if self.activation_granularity != ActivationGranularity.CLS_TOKEN:
@@ -421,9 +394,7 @@ class BaseConceptInterpretationMethod(ABC):
             # so that we can get correct CLS activations
 
             # first step extract the template
-            template_ids = self.concept_explainer.splitter.tokenizer(
-                "a", return_tensors="pt"
-            )["input_ids"]
+            template_ids = self.concept_explainer.splitter.tokenizer("a", return_tensors="pt")["input_ids"]
 
             # if we are not in a template [CLS] a [EOS]
             if len(template_ids) != 3:  # type: ignore
@@ -449,9 +420,7 @@ class BaseConceptInterpretationMethod(ABC):
 
         # compute the vocabulary's concepts activations
         with torch.no_grad():
-            concepts_activations = self.concept_explainer.activations_to_concepts(
-                latent_activations
-            )
+            concepts_activations = self.concept_explainer.activations_to_concepts(latent_activations)
         return inputs, concepts_activations
 
     @jaxtyped(typechecker=beartype)
@@ -486,8 +455,7 @@ class BaseConceptInterpretationMethod(ABC):
         if self.activation_granularity == ActivationGranularity.TOKEN:
             # we can use the tokenizer to split the inputs into tokens
             granular_texts: list[list[str]] = [
-                self.concept_explainer.splitter.tokenizer.tokenize(text)
-                for text in inputs
+                self.concept_explainer.splitter.tokenizer.tokenize(text) for text in inputs
             ]
         else:
             # Get granular texts from the inputs
@@ -498,20 +466,14 @@ class BaseConceptInterpretationMethod(ABC):
                 truncation=True,
                 return_offsets_mapping=True,
             )
-            granular_texts: list[list[str]] = (
-                self.activation_granularity.value.get_decomposition(  # type: ignore  (sure list[list[str]] with return_text=True)
-                    tokens,
-                    tokenizer=self.concept_explainer.splitter.tokenizer,
-                    return_text=True,
-                )
+            granular_texts: list[list[str]] = self.activation_granularity.value.get_decomposition(  # type: ignore  (sure list[list[str]] with return_text=True)
+                tokens,
+                tokenizer=self.concept_explainer.splitter.tokenizer,
+                return_text=True,
             )
 
-        granular_flattened_texts = [
-            text for sample_texts in granular_texts for text in sample_texts
-        ]
-        granular_flattened_sample_id = [
-            i for i, sample_texts in enumerate(granular_texts) for _ in sample_texts
-        ]
+        granular_flattened_texts = [text for sample_texts in granular_texts for text in sample_texts]
+        granular_flattened_sample_id = [i for i, sample_texts in enumerate(granular_texts) for _ in sample_texts]
         return granular_flattened_texts, granular_flattened_sample_id
 
     def get_granular_inputs_and_concept_activations(
@@ -558,9 +520,7 @@ class BaseConceptInterpretationMethod(ABC):
 
         """
         if concepts_indices == "all":
-            concepts_indices = list(
-                range(self.concept_explainer.concept_model.nb_concepts)
-            )
+            concepts_indices = list(range(self.concept_explainer.concept_model.nb_concepts))
 
         # compute the concepts activations from the provided source, can also create inputs from the vocabulary
         if self.use_vocab:
@@ -568,9 +528,7 @@ class BaseConceptInterpretationMethod(ABC):
             # Case 1: use_vocab=True
             granular_inputs: list[str]
             sure_concepts_activations: Float[torch.Tensor, "nl cpt"]
-            granular_inputs, sure_concepts_activations = (
-                self.concepts_activations_from_vocab()
-            )
+            granular_inputs, sure_concepts_activations = self.concepts_activations_from_vocab()
 
             granular_sample_ids: list[int] = list(range(len(granular_inputs)))
         else:

--- a/interpreto/concepts/methods/overcomplete.py
+++ b/interpreto/concepts/methods/overcomplete.py
@@ -179,7 +179,7 @@ class SAEExplainer(ConceptAutoEncoderExplainer[oc_sae.SAE], Generic[_SAE_co]):
 
         Returns:
             concept_model_class (type[overcomplete.sae.SAE]): One of the supported [Overcomplete SAE](https://kempnerinstitute.github.io/overcomplete/saes/vanilla/)
-                variants. Supported classes are available in [interpreto.concepts.SAEExplainerClasses]().
+                variants. Supported classes are available in `interpreto.concepts.SAEExplainerClasses`.
         """
         raise NotImplementedError
 
@@ -331,7 +331,7 @@ class DictionaryLearningExplainer(ConceptAutoEncoderExplainer[oc_opt.BaseOptimDi
     """Code: [:octicons-mark-github-24: `concepts/methods/overcomplete.py` ](https://github.com/FOR-sight-ai/interpreto/blob/dev/interpreto/concepts/methods/overcomplete.py)
 
     Implementation of a concept explainer using an
-    [overcomplete.optimization.BaseOptimDictionaryLearning](https://github.com/KempnerInstitute/overcomplete/blob/main/overcomplete/optimization/base.py)
+    `overcomplete.optimization.BaseOptimDictionaryLearning`
         (NMF and PCA variants) as `concept_model`.
 
     Attributes:
@@ -339,7 +339,7 @@ class DictionaryLearningExplainer(ConceptAutoEncoderExplainer[oc_opt.BaseOptimDi
             It should have at least one split point on which `concept_model` can be fitted.
         split_point (str | None): The split point used to train the `concept_model`. Default: `None`, set only when
             the concept explainer is fitted.
-        concept_model (overcomplete.optimization.BaseOptimDictionaryLearning): An [Overcomplete BaseOptimDictionaryLearning](https://github.com/KempnerInstitute/overcomplete/blob/main/overcomplete/optimization/base.py)
+        concept_model (overcomplete.optimization.BaseOptimDictionaryLearning): An Overcomplete BaseOptimDictionaryLearning
             variant for concept extraction.
         is_fitted (bool): Whether the `concept_model` was fit on model activations.
         has_differentiable_concept_encoder (bool): Whether the `activations_to_concepts` operation is differentiable.
@@ -394,7 +394,7 @@ class DictionaryLearningExplainer(ConceptAutoEncoderExplainer[oc_opt.BaseOptimDi
         Defines the concept model class to use for the explainer.
 
         Returns:
-            concept_model_class (type[overcomplete.optimization.BaseOptimDictionaryLearning]): One of the supported [Overcomplete BaseOptimDictionaryLearning](https://github.com/KempnerInstitute/overcomplete/blob/main/overcomplete/optimization/base.py)
+            concept_model_class (type[overcomplete.optimization.BaseOptimDictionaryLearning]): One of the supported Overcomplete BaseOptimDictionaryLearning
                 variants for concept extraction.
         """
         raise NotImplementedError
@@ -464,7 +464,7 @@ class TopKSAEConcepts(SAEExplainer[oc_sae.TopKSAE]):
 
     `ConceptAutoEncoderExplainer` with the TopK SAE from Gao et al. (2024)[^3] as concept model.
 
-    TopK SAE implementation from [overcomplete.sae.TopKSAE](https://kempnerinstitute.github.io/overcomplete/saes/topk_sae/) class.
+    TopK SAE implementation from [overcomplete.sae.TopKSAE](https://kempnerinstitute.github.io/overcomplete/saes/topk/) class.
 
     [^3]:
         Gao, L. et al., [Scaling and evaluating sparse autoencoders](https://openreview.net/forum?id=tcsZt9ZNKD).
@@ -481,7 +481,7 @@ class BatchTopKSAEConcepts(SAEExplainer[oc_sae.BatchTopKSAE]):
 
     `ConceptAutoEncoderExplainer` with the BatchTopK SAE from Bussmann et al. (2024)[^4] as concept model.
 
-    BatchTopK SAE implementation from [overcomplete.sae.BatchTopKSAE](https://kempnerinstitute.github.io/overcomplete/saes/batchtopk_sae/) class.
+    BatchTopK SAE implementation from [overcomplete.sae.BatchTopKSAE](https://kempnerinstitute.github.io/overcomplete/saes/batchtopk/) class.
 
     [^4]:
         Bussmann, B., Leask, P., Nanda, N. [BatchTopK Sparse Autoencoders](https://arxiv.org/abs/2412.06410).
@@ -498,7 +498,7 @@ class JumpReLUSAEConcepts(SAEExplainer[oc_sae.JumpSAE]):
 
     `ConceptAutoEncoderExplainer` with the JumpReLU SAE from Rajamanoharan et al. (2024)[^5] as concept model.
 
-    JumpReLU SAE implementation from [overcomplete.sae.JumpReLUSAE](https://kempnerinstitute.github.io/overcomplete/saes/jump_sae/) class.
+    JumpReLU SAE implementation from [overcomplete.sae.JumpReLUSAE](https://kempnerinstitute.github.io/overcomplete/saes/jumprelu/) class.
 
     [^5]:
         Rajamanoharan, S. et al., [Jumping Ahead: Improving Reconstruction Fidelity with JumpReLU Sparse Autoencoders](https://arxiv.org/abs/2407.14435).
@@ -533,7 +533,7 @@ class NMFConcepts(DictionaryLearningExplainer[oc_opt.NMF]):
 
     `ConceptAutoEncoderExplainer` with the NMF from Lee and Seung (1999)[^1] as concept model.
 
-    NMF implementation from [overcomplete.optimization.NMF](https://kempnerinstitute.github.io/overcomplete/optimization/nmf/) class.
+    NMF implementation from `overcomplete.optimization.NMF` class.
 
     [^1]:
         Lee, D., Seung, H. [Learning the parts of objects by non-negative matrix factorization](https://doi.org/10.1038/44565).
@@ -619,7 +619,7 @@ class SemiNMFConcepts(DictionaryLearningExplainer[oc_opt.SemiNMF]):
 
     `ConceptAutoEncoderExplainer` with the SemiNMF from Ding et al. (2008)[^2] as concept model.
 
-    SemiNMF implementation from [overcomplete.optimization.SemiNMF](https://kempnerinstitute.github.io/overcomplete/optimization/semi_nmf/) class.
+    SemiNMF implementation from `overcomplete.optimization.SemiNMF` class.
 
     [^2]:
         C. H. Q. Ding, T. Li and M. I. Jordan, [Convex and Semi-Nonnegative Matrix Factorizations](https://ieeexplore.ieee.org/document/4685898).
@@ -638,7 +638,7 @@ class ConvexNMFConcepts(DictionaryLearningExplainer[oc_opt.ConvexNMF]):
 
     `ConceptAutoEncoderExplainer` with the ConvexNMF from Ding et al. (2008)[^2] as concept model.
 
-    ConvexNMF implementation from [overcomplete.optimization.ConvexNMF](https://kempnerinstitute.github.io/overcomplete/optimization/convex_nmf/) class.
+    ConvexNMF implementation from `overcomplete.optimization.ConvexNMF` class.
 
     [^2]:
         C. H. Q. Ding, T. Li and M. I. Jordan, [Convex and Semi-Nonnegative Matrix Factorizations](https://ieeexplore.ieee.org/document/4685898).
@@ -684,7 +684,7 @@ class DictionaryLearningConcepts(DictionaryLearningExplainer[oc_opt.SkDictionary
 
     `ConceptAutoEncoderExplainer` with the Dictionary Learning concepts from Mairal et al. (2009)[^5] as concept model.
 
-    Dictionary Learning implementation from [overcomplete.optimization.SkDictionaryLearning](https://kempnerinstitute.github.io/overcomplete/optimization/sklearn/) class.
+    Dictionary Learning implementation from `overcomplete.optimization.SkDictionaryLearning` class.
 
     [^5]:
         J. Mairal, F. Bach, J. Ponce, G. Sapiro, [Online dictionary learning for sparse coding](https://www.di.ens.fr/~fbach/mairal_icml09.pdf)
@@ -701,7 +701,7 @@ class SparsePCAConcepts(DictionaryLearningExplainer[oc_opt.SkSparsePCA]):
 
     `ConceptAutoEncoderExplainer` with SparsePCA as concept model.
 
-    SparsePCA implementation from [overcomplete.optimization.SkSparsePCA](https://kempnerinstitute.github.io/overcomplete/optimization/sklearn/) class.
+    SparsePCA implementation from `overcomplete.optimization.SkSparsePCA` class.
     """
 
     @property

--- a/interpreto/concepts/metrics/consim.py
+++ b/interpreto/concepts/metrics/consim.py
@@ -181,9 +181,6 @@ class ConSim:
         classes: list[str] | None
             The names of classes of the dataset.
 
-        split_point: str
-            Where to split the model to explain.
-
     Attributes:
         classes: list[str] | None
             The names of classes of the dataset.

--- a/interpreto/concepts/metrics/consim.py
+++ b/interpreto/concepts/metrics/consim.py
@@ -1237,10 +1237,8 @@ class ConSim:
                     The response of the LLM on the prompts should be compared to the model predictions.
 
         Raises:
-            ValueError
-                If the model predictions and the user-llm predictions have different lengths.
-            Warnings
-                If the user-llm response is empty or the format is not respected.
+            ValueError: If the model predictions and the user-llm predictions have different lengths.
+            UserWarning: If the user-llm response is empty or the format is not respected; the method returns None.
         """
         local_importances: torch.Tensor | None = None
         if concept_explainer is not None:

--- a/interpreto/concepts/probes/__init__.py
+++ b/interpreto/concepts/probes/__init__.py
@@ -27,7 +27,7 @@ Probe models for concept-based interpretability.
 
 This package provides lightweight torch-based probe models that map latent
 activations to concept scores. All probes follow the
-[ConceptModelProtocol][interpreto.typing.ConceptModelProtocol] interface (structurally) and
+`ConceptModelProtocol` interface (structurally) and
 support `state_dict` serialization for reproducibility.
 
 Probe families:

--- a/interpreto/concepts/probes/base.py
+++ b/interpreto/concepts/probes/base.py
@@ -25,13 +25,13 @@
 """
 Base class for torch-based probe models.
 
-This module defines [Probe][interpreto.concepts.probes.base.Probe], the abstract base
+This module defines [Probe][interpreto.concepts.probes.Probe], the abstract base
 for all probe models in the package. It provides:
 
 - A `fitted` flag persisted as a buffer (survives `state_dict` round-trips).
-- A [load_state_dict][interpreto.concepts.probes.base.Probe.load_state_dict] override that
+- A [load_state_dict][interpreto.concepts.probes.Probe.load_state_dict] override that
   handles dynamically-sized buffers and parameters created during
-  [fit][interpreto.concepts.probes.base.Probe.fit]. Thus allowing saving and loading probes.
+  [fit][interpreto.concepts.probes.Probe.fit]. Thus allowing saving and loading probes.
 - The [assert_fitted][interpreto.concepts.probes.base.assert_fitted] decorator to guard methods
   that require a fitted model.
 
@@ -85,12 +85,12 @@ class Probe(nn.Module, ABC):
     """
     Abstract base for all torch-based probe models.
 
-    Satisfies [ConceptModelProtocol][interpreto.typing.ConceptModelProtocol] structurally
+    Satisfies `ConceptModelProtocol` structurally
     (no inheritance from `Protocol` needed at runtime).
 
     Subclasses must implement:
-        - [fit][interpreto.concepts.probes.base.Probe.fit] — learn probe parameters from activations and labels.
-        - [encode][interpreto.concepts.probes.base.Probe.encode] — map activations to concept scores.
+        - [fit][interpreto.concepts.probes.Probe.fit] — learn probe parameters from activations and labels.
+        - [encode][interpreto.concepts.probes.Probe.encode] — map activations to concept scores.
 
     Attributes:
         nb_concepts (int): Number of concepts the probe was fitted on. Set by subclasses.
@@ -152,7 +152,7 @@ class Probe(nn.Module, ABC):
         """Load a state dict, handling dynamically-sized buffers/parameters.
 
         Probes register buffers with shape `(0,)` at `__init__` time. After
-        [fit][interpreto.concepts.probes.base.Probe.fit], these become their real shapes
+        [fit][interpreto.concepts.probes.Probe.fit], these become their real shapes
         (e.g. `(c, d)`). When loading a fitted state dict into a fresh probe, the standard
         `nn.Module.load_state_dict` would raise a size-mismatch error.
 
@@ -185,11 +185,11 @@ class Probe(nn.Module, ABC):
 
 
 class ProbeExplainer(ConceptEncoderExplainer[Probe]):
-    """Concept explainer backed by a [Probe][interpreto.concepts.probes.base.Probe].
+    """Concept explainer backed by a `Probe`.
 
     Integrates any pre-instantiated torch probe into the concept explainer
     pipeline, connecting it to a
-    [BaseSplitter][interpreto.concepts.splitters.base_splitter.BaseSplitter]
+    `BaseSplitter`
     for activation extraction.
 
     The probe is provided already instantiated (unfitted or pre-fitted).
@@ -197,8 +197,8 @@ class ProbeExplainer(ConceptEncoderExplainer[Probe]):
     delegates to the probe's own `fit` method.
 
     Args:
-        splitter (BaseSplitter): Wrapped transformer model.
-        concept_model (Probe): An instantiated torch probe.
+        splitter (interpreto.concepts.splitters.BaseSplitter): Wrapped transformer model.
+        concept_model (interpreto.concepts.probes.Probe): An instantiated torch probe.
         split_point (str | None): Layer name to extract activations from.
 
     Example::

--- a/interpreto/concepts/probes/base.py
+++ b/interpreto/concepts/probes/base.py
@@ -199,7 +199,6 @@ class ProbeExplainer(ConceptEncoderExplainer[Probe]):
     Args:
         splitter (interpreto.concepts.splitters.BaseSplitter): Wrapped transformer model.
         concept_model (interpreto.concepts.probes.Probe): An instantiated torch probe.
-        split_point (str | None): Layer name to extract activations from.
 
     Example::
 

--- a/interpreto/concepts/probes/sklearn.py
+++ b/interpreto/concepts/probes/sklearn.py
@@ -54,7 +54,7 @@ from interpreto.typing import ConceptsActivations, LatentActivations
 class SklearnProbe:
     """Probe wrapping a scikit-learn classifier with `decision_function`.
 
-    Satisfies [ConceptModelProtocol][interpreto.typing.ConceptModelProtocol] structurally.
+    Satisfies `ConceptModelProtocol` structurally.
     Currently limited to a single binary concept.
 
     Args:
@@ -88,11 +88,11 @@ class SklearnProbeExplainer(ConceptEncoderExplainer[SklearnProbe]):
 
     Integrates [SklearnProbe][interpreto.concepts.probes.sklearn.SklearnProbe] into the concept
     explainer pipeline, connecting it to a
-    [BaseSplitter][interpreto.concepts.splitters.base_splitter.BaseSplitter]
+    `BaseSplitter`
     for activation extraction.
 
     Args:
-        splitter (BaseSplitter): Wrapped transformer model.
+        splitter (interpreto.concepts.splitters.BaseSplitter): Wrapped transformer model.
         sklearn_class (Any): Scikit-learn estimator class (default: `SVC`).
         sklearn_kwargs (dict[str, Any]): Arguments forwarded to the sklearn estimator.
     """

--- a/interpreto/concepts/splitters/model_with_split_points.py
+++ b/interpreto/concepts/splitters/model_with_split_points.py
@@ -708,7 +708,7 @@ class ModelWithSplitPoints(BaseSplitter):
         Optionally include the model predictions in the returned tuple.
 
         Args:
-            inputs list[str] | torch.Tensor | BatchEncoding:
+            inputs (list[str] | torch.Tensor | BatchEncoding):
                 Inputs to the model forward pass before or after tokenization.
                 In the case of a `torch.Tensor`, we assume a batch dimension and token ids.
 

--- a/interpreto/concepts/splitters/model_with_split_points.py
+++ b/interpreto/concepts/splitters/model_with_split_points.py
@@ -97,7 +97,7 @@ AG = ActivationGranularity
 
 
 class ModelWithSplitPoints(BaseSplitter):
-    """Code: [:octicons-mark-github-24: concepts.splitters/model_with_split_points.py` ](https://github.com/FOR-sight-ai/interpreto/blob/dev/interpreto/concepts.splitters/model_with_split_points.py)
+    """Code: [:octicons-mark-github-24: `concepts/splitters/model_with_split_points.py`](https://github.com/FOR-sight-ai/interpreto/blob/main/interpreto/concepts/splitters/model_with_split_points.py)
 
     The `ModelWithSplitPoints` is a wrapper around your HuggingFace model.
     Its goal is to allow you to split your model at specified locations and extract activations.

--- a/interpreto/concepts/splitters/splitter_for_classification.py
+++ b/interpreto/concepts/splitters/splitter_for_classification.py
@@ -95,7 +95,7 @@ class SplitterForClassification(BaseSplitter):
             batch_size (int): Batch size for activation extraction and gradient computation.
             device_map (torch.device | str | None): Device on which to load the model
                 (e.g., ``"cuda"`` or ``"cpu"``).
-            **kwargs: Additional keyword arguments forwarded to ``BaseSplitter``.
+            **kwargs (dict[str, Any]): Additional keyword arguments forwarded to ``BaseSplitter``.
 
         Raises:
             ValueError: If ``model_or_repo_id`` is a PreTrainedModel that is not a
@@ -195,7 +195,7 @@ class SplitterForClassification(BaseSplitter):
             inputs (list[str] | torch.Tensor | BatchEncoding | dict[str, torch.Tensor] | None):
                 Raw model inputs. Can be a list of strings, a tensor of input IDs,
                 a BatchEncoding, or a dictionary of tensors.
-            **kwargs: Additional keyword arguments forwarded to the trace context
+            **kwargs (dict[str, Any]): Additional keyword arguments forwarded to the trace context
                 (e.g., ``truncation=True``).
 
         Returns:
@@ -255,7 +255,7 @@ class SplitterForClassification(BaseSplitter):
             tqdm_bar (bool): Whether to display a progress bar.
             forward_kwargs (dict[str, Any]): Additional keyword arguments for
                 the model forward pass (e.g., ``{"truncation": True}``).
-            **kwargs: Unused, kept for API compatibility with ``ModelWithSplitPoints``.
+            **kwargs (dict[str, Any]): Unused, kept for API compatibility with ``ModelWithSplitPoints``.
 
         Returns:
             tuple[LatentActivations, torch.Tensor]: The activations tensor of shape

--- a/interpreto/concepts/splitters/splitter_for_generation.py
+++ b/interpreto/concepts/splitters/splitter_for_generation.py
@@ -81,7 +81,7 @@ class SplitterForGeneration(BaseSplitter):
         config (PretrainedConfig | None): Model configuration.
         batch_size (int): Batch size for batched operations.
         device_map (torch.device | str | None): Device on which to load the model.
-        **kwargs: Additional keyword arguments forwarded to NNsight.
+        **kwargs (dict[str, Any]): Additional keyword arguments forwarded to ``BaseSplitter.__init__`` and used for NNsight model loading.
 
     Example:
         ```python
@@ -260,7 +260,7 @@ class SplitterForGeneration(BaseSplitter):
                 If False, returns a list of sample-wise activations.
             tqdm_bar (bool): Whether to display a progress bar.
             forward_kwargs (dict[str, Any]): Additional kwargs for the model forward pass.
-            **kwargs: Unused, kept for API compatibility.
+            **kwargs (dict[str, Any]): Unused, kept for API compatibility.
 
         Returns:
             activations (list[LatentActivations] | LatentActivations):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,10 @@ plugins:
               - "!^get_content_height$"
               - "!^compose_add_child$"
 
+validation:
+  links:
+    anchors: ignore
+
 # hooks: TODO create files to automate the generation of method tables
 #   - docs/generate_attribution_explainers_overview_table.py
 #   - docs/generate_concept_explainers_overview_table.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
         - Optimization Methods: api/concepts/concept_spaces/optim.md
         - SAEs (Sparse AutoEncoders): api/concepts/concept_spaces/sae.md
       - Interpretations:
+        - Base Classes & Utilities: api/concepts/interpretations/base.md
         - TopKInputs: api/concepts/interpretations/topk_inputs.md
         - LLM Labels: api/concepts/interpretations/llm_labels.md
         - Concept Attributions: api/concepts/interpretations/concept_attributions.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,7 @@ nav:
 
 plugins:
   - search
-  - mknotebooks:
+  - mkdocs-jupyter:
       execute: false
   - autorefs
   - section-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,13 +92,14 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-  "mkdocs>=1.6.1",
+  "mkdocs>=1.6.1,<2",
   "mkdocs-material>=9.5.34",
   "mkdocs-autorefs>=1.1.0",
   "mkdocs-section-index>=0.3.9",
   "mkdocstrings>=0.25.2",
   "mkdocstrings-python>=1.10.9",
   "mkdocs-jupyter>=0.26.3",
+  "ruff",
   "docstr-coverage>=2.3.2",
 ]
 lint = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ lint = [
   "pytest>=7.2.0",
   "pytest-cov>=4.0.0",
   "pytest-xdist>=3.5.0",
-  "ruff>=0.2.0",
+  # Review this pin intentionally before 2027-01-01.
+  "ruff==0.16.4",
   "virtualenv>=20.26.6",
   "networkx>=3.0.0",
   "numpy>=2.2.0",
@@ -184,6 +185,7 @@ packages = ["interpreto"]
 
 
 [tool.ruff]
+required-version = "==0.16.4"
 target-version = "py310"
 exclude = [
   ".git",
@@ -222,6 +224,7 @@ ignore = [
   "F821",    # undefined name
   "PLR2004", # unnamed numerical constants used
   "PLR0913", # too many arguments
+  "PLR0917", # too many positional arguments; existing public APIs preserve positional compatibility
   "PLR0915", # too many statements
   "UP037",   # invalid type annotation (incompatible with single dimension jaxtyping)
   "W191",    # indentation contains tabs (handled by format)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dependencies = [
   "nnsight>=0.7.0,<0.8.0",
   "jaxtyping<=0.2.36",
   "beartype",
-  "mknotebooks",
   "pymdown-extensions",
   "bitsandbytes>=0.48.1",
   "scipy",
@@ -99,7 +98,7 @@ docs = [
   "mkdocs-section-index>=0.3.9",
   "mkdocstrings>=0.25.2",
   "mkdocstrings-python>=1.10.9",
-  "mknotebooks>=0.8.0",
+  "mkdocs-jupyter>=0.26.3",
   "docstr-coverage>=2.3.2",
 ]
 lint = [


### PR DESCRIPTION
## Description

Solves a collection of issues:
- Add `forward_kwargs` in splitters to allow specifying `truncation=True`.
- In some weird case, Shap was called with a `mask_dim=0`. It now supports this.
- Clean all error messages and warnings from the documentation compilation:
  - Treat broken links
  - Update some docstrings
  - Remove empty changelogs
  - Force `mkdocs==1.x`
  - Build doc only once
- Fix issue #159 by fixing `ruff==0.16.4`
- Fix notebook rendering errors in the doc by migrating from `mknotebooks` to `mkdocs-jupyter`
- Concept interpretations support `use_unique_words` with `SAMPLE` granularity

## Related Issue

#159 

## Type of Change

- 📚 Examples / docs / tutorials / dependencies update
- 🔧 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/FOR-sight-ai/interpreto/blob/main/docs/contributing.md) guide.
- [x] I've successfully run the style checks using `make lint`.
- [x] I've written tests for all new methods and classes that I created and successfully ran `make test`.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
